### PR TITLE
:arrow_up: Upgrade mozilla-django-oidc-db to 0.7.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -113,7 +113,7 @@ markupsafe==2.0.1
     # via jinja2
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db==0.7.1
+mozilla-django-oidc-db==0.7.2
     # via -r requirements/base.in
 oyaml==1.0
     # via vng-api-common

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -240,7 +240,7 @@ mozilla-django-oidc==1.2.4
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.7.1
+mozilla-django-oidc-db==0.7.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -299,7 +299,7 @@ mozilla-django-oidc==1.2.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.7.1
+mozilla-django-oidc-db==0.7.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
to fix an issue causing many cache calls: https://github.com/Gemeente-DenHaag/Common-Ground-Platform/pull/73