### PR TITLE
Updated docs and URLs to use new Github location

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -44,8 +44,8 @@ development machine.
 
    .. code-block:: bash
 
-       $ git clone git@bitbucket.org:maykinmedia/openklant.git
-       $ cd openklant
+       $ git clone git@github.com:maykinmedia/open-klant.git
+       $ cd open-klant
 
 3. Install all required (backend) libraries.
    **Tip:** You can use the ``bootstrap.py`` script to install the requiments
@@ -105,7 +105,7 @@ When updating an existing installation:
 
    .. code-block:: bash
 
-       $ cd openklant
+       $ cd open-klant
        $ source env/bin/activate
 
 2. Update the code and libraries:
@@ -163,11 +163,11 @@ The easiest way to get the project started is by using `Docker Compose`_.
 
    .. code-block:: bash
 
-       $ git clone git@bitbucket.org:maykinmedia/openklant.git
+       $ git clone git@github.com:maykinmedia/open-klant.git
        Cloning into 'openklant'...
        ...
 
-       $ cd openklant
+       $ cd open-klant
 
 2. Start the database and web services:
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Open Klant
 ==========
 
 :Version: 0.1.0
-:Source: https://bitbucket.org/maykinmedia/openklant
+:Source: https://github.com/maykinmedia/open-klant
 :Keywords: ``klanten``, ``contactmomenten``, ``API``, ``Common Ground``
 :License: EUPL
 :PythonVersion: 3.8

--- a/docs/install/dev.rst
+++ b/docs/install/dev.rst
@@ -11,8 +11,8 @@ Quick start
 
 #. Get the code::
 
-    $ git clone git@bitbucket.org:maykinmedia/openklant.git
-    $ cd openklant
+    $ git clone git@github.com:maykinmedia/open-klant.git
+    $ cd open-klant
 
 #. Bootstrap the virtual environment and install all required libraries. The
    ``bootstrap.py`` script basically sets the proper Django settings file to be

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@bitbucket.org/maykinmedia/openklant.git"
+    "url": "git+ssh://git@github.com/maykinmedia/open-klant.git"
   },
   "author": "Maykin Media",
   "license": "UNLICENSED",

--- a/src/openklant/conf/api.py
+++ b/src/openklant/conf/api.py
@@ -38,6 +38,8 @@ SWAGGER_SETTINGS.update(
     }
 )
 
+VNG_COMPONENTS_BRANCH = "master"
+
 GEMMA_URL_INFORMATIEMODEL_VERSIE = "1.0"
 
 # SELF_REPO = "VNG-Realisatie/klanten-api"

--- a/src/openklant/utils/context_processors.py
+++ b/src/openklant/utils/context_processors.py
@@ -8,6 +8,7 @@ def settings(request):
         "SHOW_ALERT",
         "SITE_TITLE",
         "PROJECT_NAME",
+        "VNG_COMPONENTS_BRANCH",
     )
 
     context = {


### PR DESCRIPTION
I'm not 100% if I got all references that use the repository or cloned directory name (which also changed from `openklant` to `open-klant`)