### PR TITLE
Added cache environment variables in INSTALL.rst

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -153,6 +153,9 @@ file or as part of the ``(post)activate`` of your virtualenv.
   logger and will send errors/logging to Sentry. If unset, Sentry SDK will be
   disabled.
 
+* ``CACHE_DEFAULT``: location of the default cache engine. Defaults to ``localhost:6379/0``
+* ``CACHE_AXES``: location of the cache engine used by Django Axes. Defaults to ``localhost:6379/0``
+
 Docker
 ======
 


### PR DESCRIPTION
When deploying open-klant you need to set the cache environment variables to be able to login to the admin part of the application. This was not clear in the install file.

Fixed/explained #43 