### PR TITLE
:art: removed the reverse lookup fields for the create and update

### DIFF
--- a/src/openklant/components/klantinteracties/api/serializers/actoren.py
+++ b/src/openklant/components/klantinteracties/api/serializers/actoren.py
@@ -18,12 +18,6 @@ from openklant.components.klantinteracties.models.actoren import (
 from openklant.components.klantinteracties.models.constants import SoortActor
 
 
-class ObjectidentificatorSerializer(GegevensGroepSerializer):
-    class Meta:
-        model = Actor
-        gegevensgroep = "objectidentificator"
-
-
 class ActorForeignKeySerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Actor
@@ -36,7 +30,7 @@ class ActorForeignKeySerializer(serializers.HyperlinkedModelSerializer):
             "url": {
                 "view_name": "klantinteracties:actor-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van deze actor binnen deze API.",
+                "help_text": _("De unieke URL van deze actor binnen deze API."),
             },
         }
 
@@ -69,6 +63,12 @@ class MedewerkerSerializer(serializers.ModelSerializer):
             "emailadres",
             "telefoonnummer",
         )
+
+
+class ObjectidentificatorSerializer(GegevensGroepSerializer):
+    class Meta:
+        model = Actor
+        gegevensgroep = "objectidentificator"
 
 
 class ActorSerializer(
@@ -108,7 +108,7 @@ class ActorSerializer(
             "url": {
                 "view_name": "klantinteracties:actor-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van deze actor binnen deze API.",
+                "help_text": _("De unieke URL van deze actor binnen deze API."),
             },
         }
 

--- a/src/openklant/components/klantinteracties/api/serializers/digitaal_adres.py
+++ b/src/openklant/components/klantinteracties/api/serializers/digitaal_adres.py
@@ -21,7 +21,7 @@ class DigitaalAdresForeignKeySerializer(serializers.HyperlinkedModelSerializer):
             "url": {
                 "view_name": "klantinteracties:digitaaladres-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van dit digitaal adres binnen deze API.",
+                "help_text": _("De unieke URL van dit digitaal adres binnen deze API."),
             },
         }
 
@@ -69,7 +69,7 @@ class DigitaalAdresSerializer(serializers.HyperlinkedModelSerializer):
             "url": {
                 "view_name": "klantinteracties:digitaaladres-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van dit digitaal adres binnen deze API.",
+                "help_text": _("De unieke URL van dit digitaal adres binnen deze API."),
             },
         }
 

--- a/src/openklant/components/klantinteracties/api/serializers/internetaken.py
+++ b/src/openklant/components/klantinteracties/api/serializers/internetaken.py
@@ -27,7 +27,7 @@ class InterneTaakForeignKeySerializer(serializers.HyperlinkedModelSerializer):
             "url": {
                 "view_name": "klantinteracties:internetaak-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van deze interne taak binnen deze API.",
+                "help_text": _("De unieke URL van deze interne taak binnen deze API."),
             },
         }
 
@@ -64,7 +64,7 @@ class InterneTaakSerializer(serializers.HyperlinkedModelSerializer):
             "url": {
                 "view_name": "klantinteracties:internetaak-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van deze interne taak binnen deze API.",
+                "help_text": _("De unieke URL van deze interne taak binnen deze API."),
             },
         }
 
@@ -125,6 +125,6 @@ class KlantcontactInterneTaakSerializer(serializers.HyperlinkedModelSerializer):
             "url": {
                 "view_name": "klantinteracties:internetaak-detail",
                 "lookup_field": "uuid",
-                "help_text": "De unieke URL van deze interne taak binnen deze API.",
+                "help_text": _("De unieke URL van deze interne taak binnen deze API."),
             },
         }

--- a/src/openklant/components/klantinteracties/api/tests/test_klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_klantcontacten.py
@@ -4,9 +4,6 @@ from vng_api_common.tests import reverse
 from openklant.components.klantinteracties.models.tests.factories.actoren import (
     ActorFactory,
 )
-from openklant.components.klantinteracties.models.tests.factories.internetaken import (
-    InterneTaakFactory,
-)
 from openklant.components.klantinteracties.models.tests.factories.klantcontacten import (
     BetrokkeneFactory,
     BijlageFactory,
@@ -46,10 +43,6 @@ class KlantContactTests(APITestCase):
         actor, actor2 = ActorFactory.create_batch(2)
         list_url = reverse("klantinteracties:klantcontact-list")
         data = {
-            "gingOverOnderwerpobjecten": [],
-            "omvatteBijlagen": [],
-            "hadBetrokkenen": [],
-            "leiddeTotInterneTaken": [],
             "nummer": "1234567890",
             "kanaal": "kanaal",
             "onderwerp": "onderwerp",
@@ -70,10 +63,6 @@ class KlantContactTests(APITestCase):
 
         data = response.json()
 
-        self.assertEqual(data["gingOverOnderwerpobjecten"], [])
-        self.assertEqual(data["omvatteBijlagen"], [])
-        self.assertEqual(data["hadBetrokkenen"], [])
-        self.assertEqual(data["leiddeTotInterneTaken"], [])
         self.assertEqual(data["nummer"], "1234567890")
         self.assertEqual(data["kanaal"], "kanaal")
         self.assertEqual(data["onderwerp"], "onderwerp")
@@ -98,16 +87,8 @@ class KlantContactTests(APITestCase):
 
     def test_create_klantcontact_with_reverse_lookup_fields(self):
         actor, actor2 = ActorFactory.create_batch(2)
-        betrokkene = BetrokkeneFactory.create()
-        internetaak = InterneTaakFactory.create()
-        onderwerpobject = OnderwerpobjectFactory.create(klantcontact=None)
-        bijlage = BijlageFactory.create(klantcontact=None)
         list_url = reverse("klantinteracties:klantcontact-list")
         data = {
-            "gingOverOnderwerpobjecten": [{"uuid": str(onderwerpobject.uuid)}],
-            "omvatteBijlagen": [{"uuid": str(bijlage.uuid)}],
-            "hadBetrokkenen": [{"uuid": str(betrokkene.uuid)}],
-            "leiddeTotInterneTaken": [{"uuid": str(internetaak.uuid)}],
             "nummer": "1234567890",
             "kanaal": "kanaal",
             "onderwerp": "onderwerp",
@@ -128,44 +109,6 @@ class KlantContactTests(APITestCase):
 
         data = response.json()
 
-        self.assertEqual(
-            data["gingOverOnderwerpobjecten"],
-            [
-                {
-                    "uuid": str(onderwerpobject.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/onderwerpobjecten/{str(onderwerpobject.uuid)}",
-                }
-            ],
-        )
-        self.assertEqual(
-            data["omvatteBijlagen"],
-            [
-                {
-                    "uuid": str(bijlage.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/bijlagen/{str(bijlage.uuid)}",
-                },
-            ],
-        )
-        self.assertEqual(
-            data["hadBetrokkenen"],
-            [
-                {
-                    "uuid": str(betrokkene.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/betrokkenen/{str(betrokkene.uuid)}",
-                }
-            ],
-        )
-        self.assertEqual(
-            data["leiddeTotInterneTaken"],
-            [
-                {
-                    "uuid": str(internetaak.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/internetaken/{str(internetaak.uuid)}",
-                },
-            ],
-        )
-        self.assertTrue(data["hadBetrokkenen"])
-        self.assertTrue(data["leiddeTotInterneTaken"])
         self.assertEqual(data["nummer"], "1234567890")
         self.assertEqual(data["kanaal"], "kanaal")
         self.assertEqual(data["onderwerp"], "onderwerp")
@@ -187,54 +130,6 @@ class KlantContactTests(APITestCase):
                 },
             ],
         )
-
-        with self.subTest("test_ging_over_onderwerp_unique"):
-            data = {
-                "gingOverOnderwerpobjecten": [
-                    {"uuid": str(onderwerpobject.uuid)},
-                ],
-                "omvatteBijlagen": [],
-                "hadBetrokkenen": [],
-                "leiddeTotInterneTaken": [],
-                "nummer": "1234567890",
-                "kanaal": "kanaal",
-                "onderwerp": "onderwerp",
-                "hadBetrokkenActoren": [],
-                "inhoud": "inhoud",
-                "indicatieContactGelukt": True,
-                "taal": "ndl",
-                "vertrouwelijk": True,
-                "plaatsgevondenOp": "2019-08-24T14:15:22Z",
-            }
-            response = self.client.post(list_url, data)
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-            data = response.json()
-            self.assertEqual(
-                data["invalidParams"][0]["name"], "gingOverOnderwerpobjecten.0.uuid"
-            )
-
-        with self.subTest("test_bijlage_unique"):
-            data = {
-                "gingOverOnderwerpobjecten": [],
-                "omvatteBijlagen": [
-                    {"uuid": str(bijlage.uuid)},
-                ],
-                "hadBetrokkenen": [],
-                "leiddeTotInterneTaken": [],
-                "nummer": "1234567890",
-                "kanaal": "kanaal",
-                "onderwerp": "onderwerp",
-                "hadBetrokkenActoren": [],
-                "inhoud": "inhoud",
-                "indicatieContactGelukt": True,
-                "taal": "ndl",
-                "vertrouwelijk": True,
-                "plaatsgevondenOp": "2019-08-24T14:15:22Z",
-            }
-            response = self.client.post(list_url, data)
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-            data = response.json()
-            self.assertEqual(data["invalidParams"][0]["name"], "omvatteBijlagen.0.uuid")
 
     def test_update_klantcontact(self):
         actor, actor2, actor3, actor4 = ActorFactory.create_batch(4)
@@ -256,10 +151,6 @@ class KlantContactTests(APITestCase):
         response = self.client.get(detail_url)
         data = response.json()
 
-        self.assertEqual(data["gingOverOnderwerpobjecten"], [])
-        self.assertEqual(data["omvatteBijlagen"], [])
-        self.assertEqual(data["hadBetrokkenen"], [])
-        self.assertEqual(data["leiddeTotInterneTaken"], [])
         self.assertEqual(data["nummer"], "1234567890")
         self.assertEqual(data["kanaal"], "kanaal")
         self.assertEqual(data["onderwerp"], "onderwerp")
@@ -283,10 +174,6 @@ class KlantContactTests(APITestCase):
         )
 
         data = {
-            "gingOverOnderwerpobjecten": [],
-            "omvatteBijlagen": [],
-            "hadBetrokkenen": [],
-            "leiddeTotInterneTaken": [],
             "nummer": "7948723947",
             "kanaal": "changed",
             "onderwerp": "changed",
@@ -305,10 +192,6 @@ class KlantContactTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        self.assertEqual(data["gingOverOnderwerpobjecten"], [])
-        self.assertEqual(data["omvatteBijlagen"], [])
-        self.assertEqual(data["hadBetrokkenen"], [])
-        self.assertEqual(data["leiddeTotInterneTaken"], [])
         self.assertEqual(data["nummer"], "7948723947")
         self.assertEqual(data["kanaal"], "changed")
         self.assertEqual(data["onderwerp"], "changed")
@@ -344,18 +227,6 @@ class KlantContactTests(APITestCase):
             vertrouwelijk=True,
             plaatsgevonden_op="2019-08-24T14:15:22Z",
         )
-        klantcontact2 = KlantcontactFactory.create()
-        onderwerpobject = OnderwerpobjectFactory.create(klantcontact=klantcontact)
-        onderwerpobject2 = OnderwerpobjectFactory.create(klantcontact=None)
-
-        bijlage = BijlageFactory.create(klantcontact=klantcontact)
-        bijlage2 = BijlageFactory.create(klantcontact=None)
-
-        betrokkene = BetrokkeneFactory.create(klantcontact=klantcontact)
-        betrokkene2 = BetrokkeneFactory.create(klantcontact=klantcontact2)
-
-        internetaak = InterneTaakFactory.create(klantcontact=klantcontact)
-        internetaak2 = InterneTaakFactory.create(klantcontact=klantcontact2)
 
         detail_url = reverse(
             "klantinteracties:klantcontact-detail",
@@ -364,14 +235,6 @@ class KlantContactTests(APITestCase):
         response = self.client.get(detail_url)
         data = response.json()
 
-        self.assertEqual(data["hadBetrokkenen"][0]["uuid"], str(betrokkene.uuid))
-        self.assertEqual(
-            data["leiddeTotInterneTaken"][0]["uuid"], str(internetaak.uuid)
-        )
-        self.assertEqual(
-            data["gingOverOnderwerpobjecten"][0]["uuid"], str(onderwerpobject.uuid)
-        )
-        self.assertEqual(data["omvatteBijlagen"][0]["uuid"], str(bijlage.uuid))
         self.assertEqual(data["nummer"], "1234567890")
         self.assertEqual(data["kanaal"], "kanaal")
         self.assertEqual(data["onderwerp"], "onderwerp")
@@ -395,10 +258,6 @@ class KlantContactTests(APITestCase):
         )
 
         data = {
-            "gingOverOnderwerpobjecten": [{"uuid": str(onderwerpobject2.uuid)}],
-            "omvatteBijlagen": [{"uuid": str(bijlage2.uuid)}],
-            "hadBetrokkenen": [{"uuid": str(betrokkene2.uuid)}],
-            "leiddeTotInterneTaken": [{"uuid": str(internetaak2.uuid)}],
             "nummer": "7948723947",
             "kanaal": "changed",
             "onderwerp": "changed",
@@ -419,42 +278,6 @@ class KlantContactTests(APITestCase):
 
         data = response.json()
 
-        self.assertEqual(
-            data["gingOverOnderwerpobjecten"],
-            [
-                {
-                    "uuid": str(onderwerpobject2.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/onderwerpobjecten/{str(onderwerpobject2.uuid)}",
-                }
-            ],
-        )
-        self.assertEqual(
-            data["omvatteBijlagen"],
-            [
-                {
-                    "uuid": str(bijlage2.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/bijlagen/{str(bijlage2.uuid)}",
-                },
-            ],
-        )
-        self.assertEqual(
-            data["hadBetrokkenen"],
-            [
-                {
-                    "uuid": str(betrokkene2.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/betrokkenen/{str(betrokkene2.uuid)}",
-                }
-            ],
-        )
-        self.assertEqual(
-            data["leiddeTotInterneTaken"],
-            [
-                {
-                    "uuid": str(internetaak2.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/internetaken/{str(internetaak2.uuid)}",
-                },
-            ],
-        )
         self.assertEqual(data["nummer"], "7948723947")
         self.assertEqual(data["kanaal"], "changed")
         self.assertEqual(data["onderwerp"], "changed")
@@ -496,10 +319,6 @@ class KlantContactTests(APITestCase):
         )
         response = self.client.get(detail_url)
         data = response.json()
-        onderwerpobject = OnderwerpobjectFactory.create(klantcontact=klantcontact)
-        bijlage = BijlageFactory.create(klantcontact=klantcontact)
-        betrokkene = BetrokkeneFactory.create(klantcontact=klantcontact)
-        internetaak = InterneTaakFactory.create(klantcontact=klantcontact)
 
         detail_url = reverse(
             "klantinteracties:klantcontact-detail",
@@ -507,20 +326,6 @@ class KlantContactTests(APITestCase):
         )
         response = self.client.get(detail_url)
         data = response.json()
-
-        self.assertEqual(len(data["gingOverOnderwerpobjecten"]), 1)
-        self.assertEqual(len(data["omvatteBijlagen"]), 1)
-        self.assertEqual(len(data["hadBetrokkenen"]), 1)
-        self.assertEqual(len(data["leiddeTotInterneTaken"]), 1)
-
-        self.assertEqual(
-            data["gingOverOnderwerpobjecten"][0]["uuid"], str(onderwerpobject.uuid)
-        )
-        self.assertEqual(data["omvatteBijlagen"][0]["uuid"], str(bijlage.uuid))
-        self.assertEqual(data["hadBetrokkenen"][0]["uuid"], str(betrokkene.uuid))
-        self.assertEqual(
-            data["leiddeTotInterneTaken"][0]["uuid"], str(internetaak.uuid)
-        )
 
         self.assertEqual(data["nummer"], "1234567890")
         self.assertEqual(data["kanaal"], "kanaal")
@@ -553,20 +358,6 @@ class KlantContactTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
-
-        self.assertEqual(len(data["gingOverOnderwerpobjecten"]), 1)
-        self.assertEqual(len(data["omvatteBijlagen"]), 1)
-        self.assertEqual(len(data["hadBetrokkenen"]), 1)
-        self.assertEqual(len(data["leiddeTotInterneTaken"]), 1)
-
-        self.assertEqual(
-            data["gingOverOnderwerpobjecten"][0]["uuid"], str(onderwerpobject.uuid)
-        )
-        self.assertEqual(data["omvatteBijlagen"][0]["uuid"], str(bijlage.uuid))
-        self.assertEqual(data["hadBetrokkenen"][0]["uuid"], str(betrokkene.uuid))
-        self.assertEqual(
-            data["leiddeTotInterneTaken"][0]["uuid"], str(internetaak.uuid)
-        )
 
         self.assertEqual(data["nummer"], "7948723947")
         self.assertEqual(data["kanaal"], "kanaal")

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -4,9 +4,6 @@ from vng_api_common.tests import reverse
 from openklant.components.klantinteracties.models.tests.factories.digitaal_adres import (
     DigitaalAdresFactory,
 )
-from openklant.components.klantinteracties.models.tests.factories.klantcontacten import (
-    BetrokkeneFactory,
-)
 from openklant.components.klantinteracties.models.tests.factories.partijen import (
     ContactpersoonFactory,
     OrganisatieFactory,
@@ -41,18 +38,14 @@ class PartijTests(APITestCase):
 
     def test_create_partij(self):
         vertegenwoordigde = PartijFactory.create()
-        betrokkene = BetrokkeneFactory.create()
         digitaal_adres, digitaal_adres2 = DigitaalAdresFactory.create_batch(2)
-        partij_identificator = PartijIdentificatorFactory.create()
         list_url = reverse("klantinteracties:partij-list")
         data = {
             "nummer": "1298329191",
             "interneNotitie": "interneNotitie",
-            "betrokkenen": [{"uuid": str(betrokkene.uuid)}],
             "digitaleAdressen": [{"uuid": str(digitaal_adres.uuid)}],
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "vertegenwoordigde": [{"uuid": str(vertegenwoordigde.uuid)}],
-            "partijIdentificatoren": [{"uuid": str(partij_identificator.uuid)}],
             "soortPartij": "persoon",
             "indicatieGeheimhouding": True,
             "voorkeurstaal": "ndl",
@@ -87,21 +80,14 @@ class PartijTests(APITestCase):
 
         data = response.json()
 
-        self.assertEqual(len(data["partijIdentificatoren"]), 1)
-        self.assertEqual(len(data["betrokkenen"]), 1)
-
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"][0]["uuid"], str(betrokkene.uuid))
         self.assertEqual(data["digitaleAdressen"][0]["uuid"], str(digitaal_adres.uuid))
         self.assertEqual(
             data["voorkeursDigitaalAdres"]["uuid"], str(digitaal_adres.uuid)
         )
         self.assertEqual(
             data["vertegenwoordigde"][0]["uuid"], str(vertegenwoordigde.uuid)
-        )
-        self.assertEqual(
-            data["partijIdentificatoren"][0]["uuid"], str(partij_identificator.uuid)
         )
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertTrue(data["indicatieGeheimhouding"])
@@ -157,11 +143,9 @@ class PartijTests(APITestCase):
             )
 
         with self.subTest("create_partij_without_foreignkey_relations"):
-            data["betrokkenen"] = []
             data["digitaleAdressen"] = []
             data["voorkeursDigitaalAdres"] = None
             data["vertegenwoordigde"] = []
-            data["partijIdentificatoren"] = []
 
             response = self.client.post(list_url, data)
 
@@ -171,11 +155,9 @@ class PartijTests(APITestCase):
 
             self.assertEqual(response_data["nummer"], "1298329191")
             self.assertEqual(response_data["interneNotitie"], "interneNotitie")
-            self.assertEqual(response_data["betrokkenen"], [])
             self.assertEqual(response_data["digitaleAdressen"], [])
             self.assertIsNone(response_data["voorkeursDigitaalAdres"])
             self.assertEqual(response_data["vertegenwoordigde"], [])
-            self.assertEqual(response_data["partijIdentificatoren"], [])
             self.assertEqual(response_data["soortPartij"], "persoon")
             self.assertTrue(response_data["indicatieGeheimhouding"])
             self.assertEqual(response_data["voorkeurstaal"], "ndl")
@@ -217,11 +199,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "1298329191",
             "interneNotitie": "interneNotitie",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "indicatieGeheimhouding": True,
             "voorkeurstaal": "ndl",
             "indicatieActief": True,
@@ -258,11 +238,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(response_data["nummer"], "1298329191")
         self.assertEqual(response_data["interneNotitie"], "interneNotitie")
-        self.assertEqual(response_data["betrokkenen"], [])
         self.assertEqual(response_data["digitaleAdressen"], [])
         self.assertIsNone(response_data["voorkeursDigitaalAdres"])
         self.assertEqual(response_data["vertegenwoordigde"], [])
-        self.assertEqual(response_data["partijIdentificatoren"], [])
         self.assertEqual(response_data["soortPartij"], "persoon")
         self.assertTrue(response_data["indicatieGeheimhouding"])
         self.assertEqual(response_data["voorkeurstaal"], "ndl")
@@ -310,11 +288,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "1298329191",
             "interneNotitie": "interneNotitie",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "indicatieGeheimhouding": True,
             "voorkeurstaal": "ndl",
             "indicatieActief": True,
@@ -347,11 +323,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(response_data["nummer"], "1298329191")
         self.assertEqual(response_data["interneNotitie"], "interneNotitie")
-        self.assertEqual(response_data["betrokkenen"], [])
         self.assertEqual(response_data["digitaleAdressen"], [])
         self.assertIsNone(response_data["voorkeursDigitaalAdres"])
         self.assertEqual(response_data["vertegenwoordigde"], [])
-        self.assertEqual(response_data["partijIdentificatoren"], [])
         self.assertEqual(response_data["soortPartij"], "organisatie")
         self.assertTrue(response_data["indicatieGeheimhouding"])
         self.assertEqual(response_data["voorkeurstaal"], "ndl")
@@ -387,11 +361,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "1298329191",
             "interneNotitie": "interneNotitie",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "indicatieGeheimhouding": True,
             "voorkeurstaal": "ndl",
             "indicatieActief": True,
@@ -431,11 +403,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(response_data["nummer"], "1298329191")
         self.assertEqual(response_data["interneNotitie"], "interneNotitie")
-        self.assertEqual(response_data["betrokkenen"], [])
         self.assertEqual(response_data["digitaleAdressen"], [])
         self.assertIsNone(response_data["voorkeursDigitaalAdres"])
         self.assertEqual(response_data["vertegenwoordigde"], [])
-        self.assertEqual(response_data["partijIdentificatoren"], [])
         self.assertEqual(response_data["soortPartij"], "contactpersoon")
         self.assertTrue(response_data["indicatieGeheimhouding"])
         self.assertEqual(response_data["voorkeurstaal"], "ndl")
@@ -479,8 +449,6 @@ class PartijTests(APITestCase):
 
     def test_update_partij(self):
         vertegenwoordigde, vertegenwoordigde2 = PartijFactory.create_batch(2)
-        betrokkene = BetrokkeneFactory.create()
-        partij_identificator = PartijIdentificatorFactory.create()
         partij = PartijFactory.create(
             nummer="1298329191",
             interne_notitie="interneNotitie",
@@ -501,7 +469,6 @@ class PartijTests(APITestCase):
             correspondentieadres_adresregel3="adres3",
             correspondentieadres_land="6030",
         )
-        betrokkene2 = BetrokkeneFactory.create(partij=partij)
         PersoonFactory.create(
             partij=partij,
             contactnaam_voorletters="P",
@@ -512,7 +479,6 @@ class PartijTests(APITestCase):
 
         digitaal_adres = DigitaalAdresFactory.create(partij=partij)
         digitaal_adres2 = DigitaalAdresFactory.create()
-        partij_identificator2 = PartijIdentificatorFactory.create(partij=partij)
 
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
@@ -520,12 +486,8 @@ class PartijTests(APITestCase):
         response = self.client.get(detail_url)
         data = response.json()
 
-        self.assertEqual(len(data["partijIdentificatoren"]), 1)
-        self.assertEqual(len(data["betrokkenen"]), 1)
-
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"][0]["uuid"], str(betrokkene2.uuid))
         self.assertEqual(
             data["digitaleAdressen"],
             [
@@ -538,9 +500,6 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(
             data["vertegenwoordigde"][0]["uuid"], str(vertegenwoordigde.uuid)
-        )
-        self.assertEqual(
-            data["partijIdentificatoren"][0]["uuid"], str(partij_identificator2.uuid)
         )
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertTrue(data["indicatieGeheimhouding"])
@@ -581,11 +540,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "6427834668",
             "interneNotitie": "changed",
-            "betrokkenen": [{"uuid": str(betrokkene.uuid)}],
             "digitaleAdressen": [{"uuid": str(digitaal_adres2.uuid)}],
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
             "vertegenwoordigde": [{"uuid": str(vertegenwoordigde2.uuid)}],
-            "partijIdentificatoren": [{"uuid": str(partij_identificator.uuid)}],
             "soortPartij": "persoon",
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
@@ -618,12 +575,8 @@ class PartijTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        self.assertEqual(len(data["partijIdentificatoren"]), 1)
-        self.assertEqual(len(data["betrokkenen"]), 1)
-
         self.assertEqual(data["nummer"], "6427834668")
         self.assertEqual(data["interneNotitie"], "changed")
-        self.assertEqual(data["betrokkenen"][0]["uuid"], str(betrokkene.uuid))
         self.assertEqual(
             data["digitaleAdressen"],
             [
@@ -638,9 +591,6 @@ class PartijTests(APITestCase):
         )
         self.assertEqual(
             data["vertegenwoordigde"][0]["uuid"], str(vertegenwoordigde2.uuid)
-        )
-        self.assertEqual(
-            data["partijIdentificatoren"][0]["uuid"], str(partij_identificator.uuid)
         )
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertFalse(data["indicatieGeheimhouding"])
@@ -718,11 +668,9 @@ class PartijTests(APITestCase):
             data = {
                 "nummer": "6427834668",
                 "interneNotitie": "changed",
-                "betrokkenen": [],
                 "digitaleAdressen": [],
                 "voorkeursDigitaalAdres": None,
                 "vertegenwoordigde": [],
-                "partijIdentificatoren": [],
                 "soortPartij": "organisatie",
                 "indicatieGeheimhouding": False,
                 "voorkeurstaal": "ger",
@@ -749,11 +697,9 @@ class PartijTests(APITestCase):
 
             self.assertEqual(data["nummer"], "6427834668")
             self.assertEqual(data["interneNotitie"], "changed")
-            self.assertEqual(data["betrokkenen"], [])
             self.assertEqual(data["digitaleAdressen"], [])
             self.assertIsNone(data["voorkeursDigitaalAdres"])
             self.assertEqual(data["vertegenwoordigde"], [])
-            self.assertEqual(data["partijIdentificatoren"], [])
             self.assertEqual(data["soortPartij"], "organisatie")
             self.assertFalse(data["indicatieGeheimhouding"])
             self.assertEqual(data["voorkeurstaal"], "ger")
@@ -815,11 +761,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
@@ -859,11 +803,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "6427834668",
             "interneNotitie": "changed",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "soortPartij": "persoon",
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
@@ -898,11 +840,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "6427834668")
         self.assertEqual(data["interneNotitie"], "changed")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
@@ -969,11 +909,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "organisatie")
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
@@ -1003,11 +941,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "6427834668",
             "interneNotitie": "changed",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "soortPartij": "organisatie",
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
@@ -1037,11 +973,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "6427834668")
         self.assertEqual(data["interneNotitie"], "changed")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "organisatie")
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
@@ -1117,11 +1051,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "contactpersoon")
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
@@ -1166,11 +1098,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "6427834668",
             "interneNotitie": "changed",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "soortPartij": "contactpersoon",
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
@@ -1206,11 +1136,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "6427834668")
         self.assertEqual(data["interneNotitie"], "changed")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "contactpersoon")
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
@@ -1290,11 +1218,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "contactpersoon")
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
@@ -1339,11 +1265,9 @@ class PartijTests(APITestCase):
         data = {
             "nummer": "6427834668",
             "interneNotitie": "changed",
-            "betrokkenen": [],
             "digitaleAdressen": [],
             "voorkeursDigitaalAdres": None,
             "vertegenwoordigde": [],
-            "partijIdentificatoren": [],
             "soortPartij": "persoon",
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
@@ -1378,11 +1302,9 @@ class PartijTests(APITestCase):
 
         self.assertEqual(data["nummer"], "6427834668")
         self.assertEqual(data["interneNotitie"], "changed")
-        self.assertEqual(data["betrokkenen"], [])
         self.assertEqual(data["digitaleAdressen"], [])
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["vertegenwoordigde"], [])
-        self.assertEqual(data["partijIdentificatoren"], [])
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
@@ -1441,10 +1363,8 @@ class PartijTests(APITestCase):
             correspondentieadres_adresregel3="adres3",
             correspondentieadres_land="6030",
         )
-        betrokkene = BetrokkeneFactory.create(partij=partij)
         digitaal_adres = DigitaalAdresFactory.create(partij=partij)
         digitaal_adres2 = DigitaalAdresFactory.create(partij=None)
-        partij_identificator = PartijIdentificatorFactory.create(partij=partij)
         PersoonFactory.create(
             partij=partij,
             contactnaam_voorletters="P",
@@ -1459,19 +1379,12 @@ class PartijTests(APITestCase):
         response = self.client.get(detail_url)
         data = response.json()
 
-        self.assertEqual(len(data["partijIdentificatoren"]), 1)
-        self.assertEqual(len(data["betrokkenen"]), 1)
-
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"][0]["uuid"], str(betrokkene.uuid))
         self.assertEqual(data["digitaleAdressen"][0]["uuid"], str(digitaal_adres.uuid))
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(
             data["vertegenwoordigde"][0]["uuid"], str(vertegenwoordigde.uuid)
-        )
-        self.assertEqual(
-            data["partijIdentificatoren"][0]["uuid"], str(partij_identificator.uuid)
         )
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertTrue(data["indicatieGeheimhouding"])
@@ -1518,21 +1431,14 @@ class PartijTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        self.assertEqual(len(data["partijIdentificatoren"]), 1)
-        self.assertEqual(len(data["betrokkenen"]), 1)
-
         self.assertEqual(data["nummer"], "1298329191")
         self.assertEqual(data["interneNotitie"], "interneNotitie")
-        self.assertEqual(data["betrokkenen"][0]["uuid"], str(betrokkene.uuid))
         self.assertEqual(data["digitaleAdressen"][0]["uuid"], str(digitaal_adres.uuid))
         self.assertEqual(
             data["voorkeursDigitaalAdres"]["uuid"], str(digitaal_adres.uuid)
         )
         self.assertEqual(
             data["vertegenwoordigde"][0]["uuid"], str(vertegenwoordigde.uuid)
-        )
-        self.assertEqual(
-            data["partijIdentificatoren"][0]["uuid"], str(partij_identificator.uuid)
         )
         self.assertEqual(data["soortPartij"], "persoon")
         self.assertTrue(data["indicatieGeheimhouding"])

--- a/src/openklant/components/klantinteracties/api/validators.py
+++ b/src/openklant/components/klantinteracties/api/validators.py
@@ -22,75 +22,75 @@ from openklant.components.klantinteracties.models.partijen import (
 
 def actor_is_valid_instance(value):
     if not isinstance(value, Actor):
-        raise serializers.ValidationError(_("Actor object doesn't exist."))
+        raise serializers.ValidationError(_("Actor object bestaat niet."))
 
 
 def actor_exists(value):
     try:
         Actor.objects.get(uuid=str(value))
     except Actor.DoesNotExist:
-        raise serializers.ValidationError(_("Actor object doesn't exist."))
+        raise serializers.ValidationError(_("Actor object bestaat niet."))
 
 
 def betrokkene_exists(value):
     try:
         Betrokkene.objects.get(uuid=str(value))
     except Betrokkene.DoesNotExist:
-        raise serializers.ValidationError(_("Betrokkene object doesn't exist."))
+        raise serializers.ValidationError(_("Betrokkene object bestaat niet."))
 
 
 def bijlage_exists(value):
     try:
         Bijlage.objects.get(uuid=str(value))
     except Bijlage.DoesNotExist:
-        raise serializers.ValidationError(_("Bijlage object doesn't exist."))
+        raise serializers.ValidationError(_("Bijlage object bestaat niet."))
 
 
 def contactpersoon_exists(value):
     try:
         Contactpersoon.objects.get(id=int(value))
     except Contactpersoon.DoesNotExist:
-        raise serializers.ValidationError(_("Contactpersoon object doesn't exist."))
+        raise serializers.ValidationError(_("Contactpersoon object bestaat niet."))
 
 
 def digitaal_adres_exists(value):
     try:
         DigitaalAdres.objects.get(uuid=str(value))
     except DigitaalAdres.DoesNotExist:
-        raise serializers.ValidationError(_("DigitaalAdres object doesn't exist."))
+        raise serializers.ValidationError(_("DigitaalAdres object bestaat niet."))
 
 
 def internetaak_exists(value):
     try:
         InterneTaak.objects.get(uuid=str(value))
     except InterneTaak.DoesNotExist:
-        raise serializers.ValidationError(_("InterneTaak object doesn't exist."))
+        raise serializers.ValidationError(_("InterneTaak object bestaat niet."))
 
 
 def klantcontact_exists(value):
     try:
         Klantcontact.objects.get(uuid=str(value))
     except Klantcontact.DoesNotExist:
-        raise serializers.ValidationError(_("Klantcontact object doesn't exist."))
+        raise serializers.ValidationError(_("Klantcontact object bestaat niet."))
 
 
 def onderwerpobject_exists(value):
     try:
         Onderwerpobject.objects.get(uuid=(str(value)))
     except Onderwerpobject.DoesNotExist:
-        raise serializers.ValidationError(_("Onderwerpobject object doesn't exist."))
+        raise serializers.ValidationError(_("Onderwerpobject object bestaat niet."))
 
 
 def organisatie_exists(value):
     try:
         Organisatie.objects.get(id=int(value))
     except Organisatie.DoesNotExist:
-        raise serializers.ValidationError(_("Organisatie object doesn't exist."))
+        raise serializers.ValidationError(_("Organisatie object bestaat niet."))
 
 
 def partij_is_valid_instance(value):
     if not isinstance(value, Partij):
-        raise serializers.ValidationError(_("Partij object doesn't exist."))
+        raise serializers.ValidationError(_("Partij object bestaat niet."))
 
 
 def partij_is_organisatie(value):
@@ -108,13 +108,11 @@ def partij_exists(value):
     try:
         Partij.objects.get(uuid=str(value))
     except Partij.DoesNotExist:
-        raise serializers.ValidationError(_("Partij object doesn't exist."))
+        raise serializers.ValidationError(_("Partij object bestaat niet."))
 
 
 def partij_identificator_exists(value):
     try:
         PartijIdentificator.objects.get(uuid=str(value))
     except PartijIdentificator.DoesNotExist:
-        raise serializers.ValidationError(
-            _("PartijIdentificator object doesn't exist.")
-        )
+        raise serializers.ValidationError(_("PartijIdentificator object bestaat niet."))


### PR DESCRIPTION
Removed every reverse lookup field in the update and create calls except digitale_adressen for easy configuration combined with voorkeurs_digitaal_adres