### PR TITLE
:sparkles: [#146] added onderwerpobject filters on klantcontact endpoint

### DIFF
--- a/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
@@ -16,12 +16,40 @@ from openklant.components.utils.filters import ExpandFilter
 
 class KlantcontactFilterSet(FilterSet):
     had_betrokkene__url = filters.CharFilter(
-        help_text=_("Zoek klantcontract object op basis van het betrokkene url"),
+        help_text=_("Zoek klantcontact object op basis van het betrokkene url"),
         method="filter_betrokkene_url",
     )
     had_betrokkene__uuid = filters.CharFilter(
-        help_text=_("Zoek klantcontract object op basis van het betrokkene uuid"),
+        help_text=_("Zoek klantcontact object op basis van het betrokkene uuid"),
         method="filter_betrokkene_uuid",
+    )
+    onderwerpobject__uuid = filters.CharFilter(
+        help_text=_("Zoek klantcontact object op basis van het onderwerpobject uuid"),
+        method="filter_onderwerpobject_uuid",
+    )
+    onderwerpobject__url = filters.CharFilter(
+        help_text=_("Zoek klantcontact object op basis van het onderwerpobject url"),
+        method="filter_onderwerpobject_url",
+    )
+    onderwerpobject__objectidentificator_objecttype = filters.CharFilter(
+        help_text=_(
+            "Zoek klantcontact object op basis van het onderwerpobject objecttype"
+        ),
+        method="filter_onderwerpobject_objectidentificator_objecttype",
+    )
+    onderwerpobject__objectidentificator_soort_object_id = filters.CharFilter(
+        help_text=_("Zoek klantcontact object op basis van het soort object ID"),
+        method="filter_onderwerpobject_objectidentificator_soort_object_id",
+    )
+    onderwerpobject__objectidentificator_object_id = filters.CharFilter(
+        help_text=_("Zoek klantcontact object op basis van het object ID"),
+        method="filter_onderwerpobject_objectidentificator_object_id",
+    )
+    onderwerpobject__objectidentificator_register = filters.CharFilter(
+        help_text=_(
+            "Zoek klantcontact object op basis van het onderwerpobject register"
+        ),
+        method="filter_onderwerpobject_objectidentificator_register",
     )
     inhoud = filters.CharFilter(
         lookup_expr="icontains",
@@ -44,6 +72,12 @@ class KlantcontactFilterSet(FilterSet):
         fields = (
             "had_betrokkene__url",
             "had_betrokkene__uuid",
+            "onderwerpobject__uuid",
+            "onderwerpobject__url",
+            "onderwerpobject__objectidentificator_objecttype",
+            "onderwerpobject__objectidentificator_soort_object_id",
+            "onderwerpobject__objectidentificator_object_id",
+            "onderwerpobject__objectidentificator_register",
             "nummer",
             "kanaal",
             "inhoud",
@@ -61,6 +95,56 @@ class KlantcontactFilterSet(FilterSet):
         try:
             url_uuid = uuid.UUID(value.split("/")[-1])
             return queryset.filter(betrokkene__uuid=url_uuid)
+        except ValueError:
+            return queryset.none()
+
+    def filter_onderwerpobject_uuid(self, queryset, name, value):
+        try:
+            onderwerpobject_uuid = uuid.UUID(value)
+            return queryset.filter(onderwerpobject__uuid=onderwerpobject_uuid)
+        except ValueError:
+            return queryset.none()
+
+    def filter_onderwerpobject_url(self, queryset, name, value):
+        try:
+            url_uuid = uuid.UUID(value.split("/")[-1])
+            return queryset.filter(onderwerpobject__uuid=url_uuid)
+        except ValueError:
+            return queryset.none()
+
+    def filter_onderwerpobject_objectidentificator_objecttype(
+        self, queryset, name, value
+    ):
+        try:
+            return queryset.filter(
+                onderwerpobject__objectidentificator_objecttype=value
+            )
+        except ValueError:
+            return queryset.none()
+
+    def filter_onderwerpobject_objectidentificator_soort_object_id(
+        self, queryset, name, value
+    ):
+        try:
+            return queryset.filter(
+                onderwerpobject__objectidentificator_soort_object_id=value
+            )
+        except ValueError:
+            return queryset.none()
+
+    def filter_onderwerpobject_objectidentificator_object_id(
+        self, queryset, name, value
+    ):
+        try:
+            return queryset.filter(onderwerpobject__objectidentificator_object_id=value)
+        except ValueError:
+            return queryset.none()
+
+    def filter_onderwerpobject_objectidentificator_register(
+        self, queryset, name, value
+    ):
+        try:
+            return queryset.filter(onderwerpobject__objectidentificator_register=value)
         except ValueError:
             return queryset.none()
 

--- a/src/openklant/components/klantinteracties/api/tests/test_filters.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_filters.py
@@ -9,6 +9,7 @@ from openklant.components.klantinteracties.models.tests.factories.digitaal_adres
 from openklant.components.klantinteracties.models.tests.factories.klantcontacten import (
     BetrokkeneFactory,
     KlantcontactFactory,
+    OnderwerpobjectFactory,
 )
 from openklant.components.klantinteracties.models.tests.factories.partijen import (
     CategorieFactory,
@@ -25,22 +26,58 @@ class KlantcontactFilterSetTests(APITestCase):
     def setUp(self):
         super().setUp()
         (
-            klantcontact,
-            klantcontact2,
-            klantcontact3,
-            klantcontact4,
+            self.klantcontact,
+            self.klantcontact2,
+            self.klantcontact3,
+            self.klantcontact4,
             self.klantcontact5,
         ) = KlantcontactFactory.create_batch(5)
         for betrokkene_klantcontact in [
-            klantcontact,
-            klantcontact2,
-            klantcontact3,
-            klantcontact4,
+            self.klantcontact,
+            self.klantcontact2,
+            self.klantcontact3,
+            self.klantcontact4,
             self.klantcontact5,
         ]:
             self.betrokkene = BetrokkeneFactory.create(
                 klantcontact=betrokkene_klantcontact
             )
+
+        self.onderwerpobject = OnderwerpobjectFactory.create(
+            klantcontact=self.klantcontact,
+            objectidentificator_objecttype="1",
+            objectidentificator_soort_object_id="1",
+            objectidentificator_object_id="1",
+            objectidentificator_register="1",
+        )
+        self.onderwerpobject2 = OnderwerpobjectFactory.create(
+            klantcontact=self.klantcontact2,
+            objectidentificator_objecttype="2",
+            objectidentificator_soort_object_id="2",
+            objectidentificator_object_id="2",
+            objectidentificator_register="2",
+        )
+        self.onderwerpobject3 = OnderwerpobjectFactory.create(
+            klantcontact=self.klantcontact3,
+            objectidentificator_objecttype="3",
+            objectidentificator_soort_object_id="3",
+            objectidentificator_object_id="3",
+            objectidentificator_register="3",
+        )
+        self.onderwerpobject4 = OnderwerpobjectFactory.create(
+            klantcontact=self.klantcontact4,
+            objectidentificator_objecttype="4",
+            objectidentificator_soort_object_id="4",
+            objectidentificator_object_id="4",
+            objectidentificator_register="4",
+        )
+        self.onderwerpobject5 = OnderwerpobjectFactory.create(
+            klantcontact=self.klantcontact5,
+            objectidentificator_objecttype="5",
+            objectidentificator_soort_object_id="5",
+            objectidentificator_object_id="5",
+            objectidentificator_register="5",
+        )
 
     def test_filter_betrokkene_uuid(self):
         response = self.client.get(
@@ -90,6 +127,146 @@ class KlantcontactFilterSetTests(APITestCase):
 
         with self.subTest("invalid_value_returns_empty_query"):
             response = self.client.get(self.url, {"had_betrokkene__url": "ValueError"})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+    def test_filter_onderwerpobject_uuid(self):
+        response = self.client.get(
+            self.url, {"onderwerpobject__uuid": f"{self.onderwerpobject5.uuid}"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(1, len(data))
+        self.assertEqual(str(self.klantcontact5.uuid), data[0]["uuid"])
+
+        with self.subTest("no_matches_found_return_empty_query"):
+            response = self.client.get(
+                self.url, {"onderwerpobject__uuid": str(uuid4())}
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+        with self.subTest("invalid_value_returns_empty_query"):
+            response = self.client.get(
+                self.url, {"onderwerpobject__uuid": "ValueError"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+    def test_filter_onderwerpobject__url(self):
+        url = f"http://testserver/klantinteracties/api/v1/onderwerpobjecten/{self.onderwerpobject5.uuid}"
+        response = self.client.get(
+            self.url,
+            {"onderwerpobject__url": url},
+        )
+        data = response.json()["results"]
+
+        self.assertEqual(1, len(data))
+        self.assertEqual(str(self.klantcontact5.uuid), data[0]["uuid"])
+
+        with self.subTest("no_matches_found_return_nothing"):
+            url = f"http://testserver/klantinteracties/api/v1/onderwerpobjecten/{str(uuid4())}"
+            response = self.client.get(
+                self.url,
+                {"onderwerpobject__url": url},
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+        with self.subTest("invalid_value_returns_empty_query"):
+            response = self.client.get(self.url, {"onderwerpobject__url": "ValueError"})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+    def test_filter_onderwerpobject_objectidentificator_objecttype(self):
+        response = self.client.get(
+            self.url,
+            {"onderwerpobject__objectidentificator_objecttype": "5"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(1, len(data))
+        self.assertEqual(str(self.klantcontact5.uuid), data[0]["uuid"])
+
+        with self.subTest("no_matches_found_return_nothing"):
+            response = self.client.get(
+                self.url,
+                {"onderwerpobject__objectidentificator_objecttype": "lorum impsum"},
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+    def test_filter_onderwerpobject_objectidentificator_soort_object_id(self):
+        response = self.client.get(
+            self.url,
+            {"onderwerpobject__objectidentificator_soort_object_id": "5"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(1, len(data))
+        self.assertEqual(str(self.klantcontact5.uuid), data[0]["uuid"])
+
+        with self.subTest("no_matches_found_return_nothing"):
+            response = self.client.get(
+                self.url,
+                {
+                    "onderwerpobject__objectidentificator_soort_object_id": "lorum impsum"
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+    def test_filter_objectidentificator_object_id(self):
+        response = self.client.get(
+            self.url,
+            {"onderwerpobject__objectidentificator_object_id": "5"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(1, len(data))
+        self.assertEqual(str(self.klantcontact5.uuid), data[0]["uuid"])
+
+        with self.subTest("no_matches_found_return_nothing"):
+            response = self.client.get(
+                self.url,
+                {"onderwerpobject__objectidentificator_object_id": "lorum impsum"},
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(response.json()["count"], 0)
+
+    def test_filter_objectidentificator_register(self):
+        response = self.client.get(
+            self.url,
+            {"onderwerpobject__objectidentificator_register": "5"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(1, len(data))
+        self.assertEqual(str(self.klantcontact5.uuid), data[0]["uuid"])
+
+        with self.subTest("no_matches_found_return_nothing"):
+            response = self.client.get(
+                self.url,
+                {"onderwerpobject__objectidentificator_register": "lorum impsum"},
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             self.assertEqual(response.json()["count"], 0)

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -1222,12 +1222,12 @@ paths:
         name: had_betrokkene__url
         schema:
           type: string
-        description: Zoek klantcontract object op basis van het betrokkene url
+        description: Zoek klantcontact object op basis van het betrokkene url
       - in: query
         name: had_betrokkene__uuid
         schema:
           type: string
-        description: Zoek klantcontract object op basis van het betrokkene uuid
+        description: Zoek klantcontact object op basis van het betrokkene uuid
       - in: query
         name: inhoud
         schema:
@@ -1246,6 +1246,36 @@ paths:
         schema:
           type: string
         description: Zoek klantcontacten met specifieke tekst in onderwerp
+      - in: query
+        name: onderwerpobject__objectidentificator_object_id
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van het object ID
+      - in: query
+        name: onderwerpobject__objectidentificator_objecttype
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van het onderwerpobject objecttype
+      - in: query
+        name: onderwerpobject__objectidentificator_register
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van het onderwerpobject register
+      - in: query
+        name: onderwerpobject__objectidentificator_soort_object_id
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van het soort object ID
+      - in: query
+        name: onderwerpobject__url
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van het onderwerpobject url
+      - in: query
+        name: onderwerpobject__uuid
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van het onderwerpobject uuid
       - name: page
         required: false
         in: query
@@ -1714,6 +1744,11 @@ paths:
         name: bezoekadres_nummeraanduiding_id
         schema:
           type: string
+      - in: query
+        name: categorierelatie__categorie__naam
+        schema:
+          type: string
+        description: Zoek partij object op basis van categorie namen.
       - in: query
         name: correspondentieadres_adresregel1
         schema:


### PR DESCRIPTION
fixes #146 

added onderwerpobject filters on klantcontact:
- onderwerpobject__uuid
- onderwerpobject__url
- onderwerpobject__objectidentificator_objecttype
- onderwerpobject__objectidentificator_soort_object_id
- onderwerpobject__objectidentificator_object_id
- onderwerpobject__objectidentificator_register