### PR TITLE
fix Trivy action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           output: 'trivy-results-docker.sarif'
           ignore-unfixed: true
       - name: Upload results to GH Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results-docker.sarif'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,25 +146,6 @@ jobs:
       - docker
 
     steps:
-      # So the scanner gets commit meta-information
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Derive version
-        id: vars
-        run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name (if present at all)
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          # PRs result in version 'merge' -> transform that into 'latest'
-          [ "$VERSION" == "merge" ] && VERSION=latest
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Download built image
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - changed-files
 
     # only run tests if source files have changed (e.g. skip for PRs that only update docs)
-    if: ${{ needs.changed-files.outputs.changed-py-files == 'true'|| needs.changed-files.outputs.changed-requirements == 'true'|| github.event_name == 'push' }}
+    if: ${{ needs.changed-files.outputs.changed-py-files == 'true'|| needs.changed-files.outputs.changed-requirements == 'true'|| github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Fixes #179

To be honest I couldn't find why uploading results to code scanning stopped working on 15.03.24. The config looks the same as in Open Zaak

What I did:
* removed unnecessary step in the image-scan job
* updated version of gh action to upload trivy report
* force tests to run and docker image to build if the action is run manually even if python files have not been changed

I want the PR to be merged to see if the changes were enough
