### PR TITLE
:memo:[#196] remove links to outdated VNG documentation

### DIFF
--- a/src/openklant/templates/index.html
+++ b/src/openklant/templates/index.html
@@ -27,22 +27,6 @@
 
     {% endblock %}
 
-    {% block extra_content %}
-      <div class="cardlist">
-        <div class="cardlist__item">
-          <div class="card">
-              <h5 class="card__title"><i class="fas fa-cogs"></i> Runtime gedrag</h5>
-              <p>Beschrijving van de business logica (VNG Standaard).</p>
-              <a href="https://vng-realisatie.github.io/gemma-zaken/standaard/{{ component }}/" class="button button--primary">
-                {{ component|capfirst }} API
-                &nbsp;&nbsp;
-                <i class="fas fa-external-link-alt"></i>
-            </a>
-          </div>
-        </div>
-      </div>
-    {% endblock %}
-
     {% block admin_link %}
       <p>
         <a href="{% url 'admin:index' %}" class="button button--alert"><i class="fas fa-lock"></i> Beheer</a>

--- a/src/openklant/templates/master.html
+++ b/src/openklant/templates/master.html
@@ -40,7 +40,6 @@
               <ul class="list">
                 <li><a class="link link--muted" href="https://open-klant.readthedocs.io/en/latest/">Documentatie</a></li>
                 <li><a class="link link--muted" href="https://github.com/maykinmedia/open-klant">Code op Github</a></li>
-                <li><a class="link link--muted" href="https://vng-realisatie.github.io/klantinteracties/">Klantinteracties API standaard</a></li>
               </ul>
             </div>
             <div class="footer__item">


### PR DESCRIPTION
Fixes #196
