### PR TITLE
:wrench: [maykinmedia/open-api-framework#40] Remove sites dependency

### DIFF
--- a/src/openklant/conf/base.py
+++ b/src/openklant/conf/base.py
@@ -15,6 +15,9 @@ INSTALLED_APPS = INSTALLED_APPS + [
     "openklant.components.klantinteracties",
     "openklant.components.contactgegevens",
 ]
+# `django.contrib.sites` is installed by Open API Framework by default
+# but we don't want to rely on it anymore (e.g. when generating the label for 2FA)
+INSTALLED_APPS.remove("django.contrib.sites")
 
 # FIXME should these be part of OAf?
 MIDDLEWARE.insert(

--- a/src/openklant/fixtures/default_admin_index.json
+++ b/src/openklant/fixtures/default_admin_index.json
@@ -67,10 +67,6 @@
                 "appgroup"
             ],
             [
-                "sites",
-                "site"
-            ],
-            [
                 "log_outgoing_requests",
                 "outgoingrequestslogconfig"
             ]


### PR DESCRIPTION
Fixes https://github.com/maykinmedia/open-api-framework/issues/40 partially

**Changes**

* Uninstall the django.contrib.sites app to ensure that we no longer rely on in when generating the label for 2FA

