### PR TITLE
Set initial `CSP_EXCLUDE_URL_PREFIXES` value in `base.py`

### DIFF
--- a/src/openklant/conf/base.py
+++ b/src/openklant/conf/base.py
@@ -48,7 +48,7 @@ SITE_TITLE = "API dashboard"
 #
 ADMIN_INDEX_SHOW_REMAINING_APPS_TO_SUPERUSERS = True
 
-CSP_EXCLUDE_URL_PREFIXES += (
+CSP_EXCLUDE_URL_PREFIXES = (
     "/contactgegevens/api/v1/schema/",
     "/klantinteracties/api/v1/schema/",
 )


### PR DESCRIPTION
Fixes the `CSP_EXCLUDE_URL_PREFIXES` not being set properly.

Encountered when running `makemigrations`:

```
Traceback (most recent call last):
  File "/home/sonny/development/open-klant/./src/manage.py", line 24, in <module>
    execute_from_command_line(sys.argv)
  File "/home/sonny/development/open-klant/env/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/home/sonny/development/open-klant/env/lib/python3.11/site-packages/django/core/management/__init__.py", line 382, in execute
    settings.INSTALLED_APPS
  File "/home/sonny/development/open-klant/env/lib/python3.11/site-packages/django/conf/__init__.py", line 102, in __getattr__
    self._setup(name)
  File "/home/sonny/development/open-klant/env/lib/python3.11/site-packages/django/conf/__init__.py", line 89, in _setup
    self._wrapped = Settings(settings_module)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sonny/development/open-klant/env/lib/python3.11/site-packages/django/conf/__init__.py", line 217, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/sonny/development/open-klant/src/openklant/conf/dev.py", line 24, in <module>
    from .base import *  # noqa isort:skip
    ^^^^^^^^^^^^^^^^^^^
  File "/home/sonny/development/open-klant/src/openklant/conf/base.py", line 51, in <module>
    CSP_EXCLUDE_URL_PREFIXES += (
    ^^^^^^^^^^^^^^^^^^^^^^^^
NameError: name 'CSP_EXCLUDE_URL_PREFIXES' is not defined
```