### PR TITLE
Feature/256 filter klantcontact on betrokkenen

### DIFF
--- a/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
@@ -28,6 +28,14 @@ class KlantcontactFilterSet(FilterSet):
         help_text=_("Zoek klantcontact object op basis van het betrokkene uuid."),
         field_name="betrokkene__uuid",
     )
+    had_betrokkene__was_partij__url = filters.CharFilter(
+        help_text=_("Zoek klantcontact object op basis van de partij url."),
+        method="filter_partij_url",
+    )
+    had_betrokkene__was_partij__uuid = filters.UUIDFilter(
+        help_text=_("Zoek klantcontact object op basis van de partij uuid."),
+        field_name="betrokkene__partij__uuid",
+    )
     onderwerpobject__url = filters.CharFilter(
         help_text=_("Zoek klantcontact object op basis van het onderwerpobject url."),
         method="filter_onderwerpobject_url",
@@ -54,6 +62,8 @@ class KlantcontactFilterSet(FilterSet):
         fields = (
             "had_betrokkene__url",
             "had_betrokkene__uuid",
+            "had_betrokkene__was_partij__url",
+            "had_betrokkene__was_partij__uuid",
             "onderwerpobject__uuid",
             "onderwerpobject__url",
             "onderwerpobject__onderwerpobjectidentificator_code_objecttype",
@@ -79,6 +89,13 @@ class KlantcontactFilterSet(FilterSet):
         try:
             url_uuid = uuid.UUID(value.rstrip("/").split("/")[-1])
             return queryset.filter(betrokkene__uuid=url_uuid)
+        except ValueError:
+            return queryset.none()
+
+    def filter_partij_url(self, queryset, name, value):
+        try:
+            url_uuid = uuid.UUID(value.rstrip("/").split("/")[-1])
+            return queryset.filter(betrokkene__partij__uuid=url_uuid)
         except ValueError:
             return queryset.none()
 

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -1583,6 +1583,17 @@ paths:
           format: uuid
         description: Zoek klantcontact object op basis van het betrokkene uuid.
       - in: query
+        name: hadBetrokkene__wasPartij__url
+        schema:
+          type: string
+        description: Zoek klantcontact object op basis van de partij url.
+      - in: query
+        name: hadBetrokkene__wasPartij__uuid
+        schema:
+          type: string
+          format: uuid
+        description: Zoek klantcontact object op basis van de partij uuid.
+      - in: query
         name: indicatieContactGelukt
         schema:
           type: boolean


### PR DESCRIPTION
Fixes #256

**Changes**

Add two filter fields to the klantcontact api endpoint:
- had_betrokkene__was_partij__url
- had_betrokkene__was_partij__uuid

