### PR TITLE
Add UUID to admin search fields and fieldsets

### DIFF
--- a/src/openklant/components/klantinteracties/admin/actoren.py
+++ b/src/openklant/components/klantinteracties/admin/actoren.py
@@ -53,7 +53,10 @@ class ActorAdmin(admin.ModelAdmin):
         "soort_actor",
         "indicatie_actief",
     )
-    search_fields = ("naam",)
+    search_fields = (
+        "naam",
+        "uuid",
+    )
     inlines = (
         ActorKlantcontactInlineAdmin,
         GeautomatiseerdeActorInlineAdmin,
@@ -61,11 +64,13 @@ class ActorAdmin(admin.ModelAdmin):
         OrganisatorischeEenheidInlineAdmin,
         InterneTaakInlineAdmin,
     )
+    readonly_fields = ("uuid",)
     fieldsets = (
         (
             None,
             {
                 "fields": [
+                    "uuid",
                     "naam",
                     "soort_actor",
                     "indicatie_actief",

--- a/src/openklant/components/klantinteracties/admin/digitaal_adres.py
+++ b/src/openklant/components/klantinteracties/admin/digitaal_adres.py
@@ -21,6 +21,9 @@ class DigitaalAdresAdminForm(forms.ModelForm):
 @admin.register(DigitaalAdres)
 class DigitaalAdresAdmin(admin.ModelAdmin):
     readonly_fields = ("uuid",)
-    search_fields = ("adres",)
+    search_fields = (
+        "adres",
+        "uuid",
+    )
     autocomplete_fields = ("partij",)
     form = DigitaalAdresAdminForm

--- a/src/openklant/components/klantinteracties/admin/internetaken.py
+++ b/src/openklant/components/klantinteracties/admin/internetaken.py
@@ -28,7 +28,10 @@ class InterneTaakAdmin(admin.ModelAdmin):
         "toegewezen_op",
         "afgehandeld_op",
     )
-    search_fields = ("nummer",)
+    search_fields = (
+        "nummer",
+        "uuid",
+    )
     list_filter = (
         "actoren",
         "status",

--- a/src/openklant/components/klantinteracties/admin/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/admin/klantcontacten.py
@@ -15,11 +15,13 @@ class BetrokkeneInlineAdmin(admin.StackedInline):
         "contactnaam_achternaam",
     )
     autocomplete_fields = ("partij",)
+    readonly_fields = ("uuid",)
     fieldsets = [
         (
             None,
             {
                 "fields": [
+                    "uuid",
                     "partij",
                     "klantcontact",
                     "rol",
@@ -70,16 +72,19 @@ class BetrokkeneInlineAdmin(admin.StackedInline):
 @admin.register(Betrokkene)
 class BetrokkeneAdmin(admin.ModelAdmin):
     search_fields = (
+        "uuid",
         "contactnaam_voorletters",
         "contactnaam_voorvoegsel_achternaam",
         "contactnaam_achternaam",
     )
     autocomplete_fields = ("partij",)
+    readonly_fields = ("uuid",)
     fieldsets = [
         (
             None,
             {
                 "fields": [
+                    "uuid",
                     "partij",
                     "klantcontact",
                     "rol",
@@ -159,8 +164,12 @@ class KlantcontactAdmin(admin.ModelAdmin):
         BijlageInlineAdmin,
         InterneTaakInlineAdmin,
     ]
-    search_fields = ("nummer",)
+    search_fields = (
+        "nummer",
+        "uuid",
+    )
     date_hierarchy = "plaatsgevonden_op"
+    readonly_fields = ("uuid",)
 
     @admin.display(empty_value="---")
     def betrokkene_namen(self, obj):


### PR DESCRIPTION
Fixes #

**Changes**

Looking up objects based on their UUID and/or fetching a UUID from a record in the admin is a common practice (e.g. because you need to match something from your logs, or match an object between systems). The UUID is also the primary key. Both are good reasons to include it in the admin field display / search fields.

