### PR TITLE
[#294] add django-setup-configuration support for mozilla-django-oidc-db

### DIFF
--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -8,3 +8,10 @@ openklant_tokens:
       organization: Organization XYZ
       application: Application XYZ
       administration: Administration XYZ
+
+oidc_db_config_enable: true
+oidc_db_config_admin_auth:
+  oidc_rp_client_id: client-id
+  oidc_rp_client_secret: secret
+  endpoint_config:
+    oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/

--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -14,4 +14,6 @@ oidc_db_config_admin_auth:
   oidc_rp_client_id: client-id
   oidc_rp_client_secret: secret
   endpoint_config:
-    oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/
+    oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+    oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+    oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo

--- a/docs/installation/setup_configuration.rst
+++ b/docs/installation/setup_configuration.rst
@@ -45,6 +45,26 @@ Create a (single) YAML configuration file with your settings:
           contact_person: Person 2
           email: person-2@example.com
 
+
+Mozilla-django-oidc-db
+----------------------
+
+Create or update the (single) YAML configuration file with your settings:
+
+.. code-block:: yaml
+
+   ...
+    oidc_db_config_enable: true
+    oidc_db_config_admin_auth:
+      oidc_rp_client_id: client-id
+      oidc_rp_client_secret: secret
+      endpoint_config:
+        oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/
+   ...
+
+More details about configuring mozilla-django-oidc-db through ``setup_configuration``
+can be found at the _`documentation`: https://mozilla-django-oidc-db.readthedocs.io/en/latest/setup_configuration.html.
+
 Execution
 =========
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,4 @@
 open-api-framework
 
 django-setup-configuration
+mozilla-django-oidc-db[setup-configuration]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -156,6 +156,7 @@ django-sessionprofile==3.0.0
 django-setup-configuration==0.4.0
     # via
     #   -r requirements/base.in
+    #   mozilla-django-oidc-db
     #   open-api-framework
 django-simple-certmanager==2.3.0
     # via zgw-consumers
@@ -236,7 +237,7 @@ maykin-2fa==1.0.1
     # via open-api-framework
 mozilla-django-oidc==4.0.1
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.20.0
     # via
     #   -r requirements/base.in
     #   open-api-framework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -236,8 +236,10 @@ maykin-2fa==1.0.1
     # via open-api-framework
 mozilla-django-oidc==4.0.1
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db==0.19.0
-    # via open-api-framework
+mozilla-django-oidc-db[setup-configuration]==0.19.0
+    # via
+    #   -r requirements/base.in
+    #   open-api-framework
 notifications-api-common==0.3.1
     # via commonground-api-common
 open-api-framework==0.9.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -422,7 +422,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.19.0
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -250,6 +250,7 @@ django-sessionprofile==3.0.0
 django-setup-configuration==0.4.0
     # via
     #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
     #   open-api-framework
 django-simple-certmanager==2.3.0
     # via
@@ -422,7 +423,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.20.0
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -257,6 +257,7 @@ django-sessionprofile==3.0.0
 django-setup-configuration==0.4.0
     # via
     #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
     #   open-api-framework
 django-simple-certmanager==2.3.0
     # via
@@ -431,7 +432,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.20.0
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -431,7 +431,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.19.0
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/src/openklant/conf/base.py
+++ b/src/openklant/conf/base.py
@@ -48,4 +48,5 @@ ADMIN_INDEX_SHOW_REMAINING_APPS_TO_SUPERUSERS = True
 #
 SETUP_CONFIGURATION_STEPS = (
     "openklant.setup_configuration.steps.TokenAuthConfigurationStep",
+    "mozilla_django_oidc_db.setup_configuration.steps.AdminOIDCConfigurationStep",
 )


### PR DESCRIPTION
Fixes #294 

**Changes**

Allows users to configure mozilla-django-oidc-db through django-setup-configuration.

