### PR TITLE
Update configuration example

### DIFF
--- a/docs/installation/setup_configuration.rst
+++ b/docs/installation/setup_configuration.rst
@@ -33,7 +33,7 @@ Create a (single) YAML configuration file with your settings:
 
     openklant_tokens_config_enable: true
     openklant_tokens:
-      group:
+      items:
         - identifier: token-1
           contact_person: Person 1
           email: person-1@example.com


### PR DESCRIPTION
Fixes the django-setup-configuration documentation

**Changes**

Shows the correct key to use in the configuration example file, see [test file ](https://github.com/maykinmedia/open-klant/commit/f05f3a31a2e164bf15153d116cc3a7442dbc6abe#diff-fc1f1bee7f49becd30664b40c0598909e2f013a86f84525dcc2ca5ecef91c237R3)for an example.