### PR TITLE
[#294] update mozilla-django-oidc-db to `0.21.1`

### DIFF
--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -11,9 +11,11 @@ openklant_tokens:
 
 oidc_db_config_enable: true
 oidc_db_config_admin_auth:
-  oidc_rp_client_id: client-id
-  oidc_rp_client_secret: secret
-  endpoint_config:
-    oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
-    oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
-    oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
+  items:
+    - identifier: admin-oidc
+      oidc_rp_client_id: client-id
+      oidc_rp_client_secret: secret
+      endpoint_config:
+        oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+        oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+        oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo

--- a/docs/installation/setup_configuration.rst
+++ b/docs/installation/setup_configuration.rst
@@ -56,10 +56,12 @@ Create or update the (single) YAML configuration file with your settings:
    ...
     oidc_db_config_enable: true
     oidc_db_config_admin_auth:
-      oidc_rp_client_id: client-id
-      oidc_rp_client_secret: secret
-      endpoint_config:
-        oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/
+    items:
+      - identifier: admin-oidc
+        oidc_rp_client_id: client-id
+        oidc_rp_client_secret: secret
+        endpoint_config:
+          oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/
    ...
 
 More details about configuring mozilla-django-oidc-db through ``setup_configuration``

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -237,7 +237,7 @@ maykin-2fa==1.0.1
     # via open-api-framework
 mozilla-django-oidc==4.0.1
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.20.0
+mozilla-django-oidc-db[setup-configuration]==0.21.1
     # via
     #   -r requirements/base.in
     #   open-api-framework

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -423,7 +423,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.20.0
+mozilla-django-oidc-db[setup-configuration]==0.21.1
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -432,7 +432,7 @@ mozilla-django-oidc==4.0.1
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db[setup-configuration]==0.20.0
+mozilla-django-oidc-db[setup-configuration]==0.21.1
     # via
     #   -r requirements/base.txt
     #   open-api-framework


### PR DESCRIPTION
Fixes #294 

**Changes**

Updates `mozilla-django-oidc-db` from `0.20.0` to `0.21.1`

