### PR TITLE
Add missing token examples in documentation

### DIFF
--- a/docs/installation/setup_configuration.rst
+++ b/docs/installation/setup_configuration.rst
@@ -35,6 +35,7 @@ Create a (single) YAML configuration file with your settings:
     openklant_tokens:
       items:
         - identifier: token-1
+          token: ba9d233e95e04c4a8a661a27daffe7c9bd019067
           contact_person: Person 1
           email: person-1@example.com
           organization: Organization XYZ # optional
@@ -42,6 +43,7 @@ Create a (single) YAML configuration file with your settings:
           administration: Administration XYZ # optional
 
         - identifier: token-2
+          token: 7b2b212d9f16d171a70a1d927cdcfbd5ca7a4799
           contact_person: Person 2
           email: person-2@example.com
 


### PR DESCRIPTION
Fixes the documentation

**Changes**

Adds the missing `token` field to the documentation example

