### PR TITLE
Feature/239 Include Partij Identificatoren on Partij for GET, POST and PUT operations

### DIFF
--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -576,7 +576,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
     def update(self, instance, validated_data):
         method = self.context.get("request").method
         partij_identificatie = validated_data.pop("partij_identificatie", None)
-        partij_identificatoren = validated_data.pop("partijidentificator_set", [])
+        partij_identificatoren = validated_data.pop("partijidentificator_set", None)
 
         if "digitaaladres_set" in validated_data:
             existing_digitale_adressen = instance.digitaaladres_set.all()
@@ -723,7 +723,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
 
         partij = super().update(instance, validated_data)
 
-        if partij_identificatoren:
+        if partij_identificatoren is not None:
             partij.partijidentificator_set.all().delete()
             for partij_identificator in partij_identificatoren:
                 partij_identificator["identificeerde_partij"] = {
@@ -757,7 +757,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
         partij_identificatie = validated_data.pop("partij_identificatie", None)
         digitale_adressen = validated_data.pop("digitaaladres_set")
         rekeningnummers = validated_data.pop("rekeningnummer_set")
-        partij_identificatoren = validated_data.pop("partijidentificator_set", [])
+        partij_identificatoren = validated_data.pop("partijidentificator_set", None)
 
         if voorkeurs_digitaal_adres := validated_data.pop(
             "voorkeurs_digitaal_adres", None
@@ -835,7 +835,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
                 rekeningnummer.partij = partij
                 rekeningnummer.save()
 
-        if partij_identificatoren:
+        if partij_identificatoren is not None:
             for partij_identificator in partij_identificatoren:
                 partij_identificator["identificeerde_partij"] = {
                     "uuid": str(partij.uuid)

--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -728,7 +728,6 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
                 partij_identificator_serializer.is_valid(raise_exception=True)
                 partij_identificator_serializer.create(partij_identificator)
 
-
         if partij_identificatie:
             serializer_class = self.discriminator.mapping[
                 validated_data.get("soort_partij")

--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -494,6 +494,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
     )
     partij_identificatoren = PartijIdentificatorSerializer(
         many=True,
+        required=False,
         source="partijidentificator_set",
         help_text=_("Partij-identificatoren die hoorde bij deze partij."),
     )

--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -751,9 +751,14 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
                     data=partij_identificator
                 )
                 partij_identificator_serializer.is_valid(raise_exception=True)
-                partij_identificator_serializer.create(
-                    partij_identificator_serializer.validated_data
-                )
+                if "uuid" in partij_identificator:
+                    PartijIdentificator.objects.filter(
+                        uuid=partij_identificator["uuid"]
+                    ).update(partij=partij)
+                else:
+                    partij_identificator_serializer.create(
+                        partij_identificator_serializer.validated_data
+                    )
 
         if partij_identificatie:
             serializer_class = self.discriminator.mapping[

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -680,6 +680,14 @@ class PartijTests(APITestCase):
         rekeningnummer = RekeningnummerFactory.create(partij=partij)
         rekeningnummer2 = RekeningnummerFactory.create()
 
+        partij_identificator = PartijIdentificatorFactory.create(
+            partij=partij,
+            partij_identificator_code_objecttype="natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="bsn",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="brp",
+        )
+
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -745,6 +753,16 @@ class PartijTests(APITestCase):
             },
         )
 
+        self.assertEqual(
+            data["partijIdentificatoren"][0]["partijIdentificator"],
+            {
+                "codeObjecttype": partij_identificator.partij_identificator_code_objecttype,
+                "codeSoortObjectId": partij_identificator.partij_identificator_code_soort_object_id,
+                "objectId": partij_identificator.partij_identificator_object_id,
+                "codeRegister": partij_identificator.partij_identificator_code_register,
+            },
+        )
+
         data = {
             "nummer": "6427834668",
             "interneNotitie": "changed",
@@ -778,6 +796,17 @@ class PartijTests(APITestCase):
                     "achternaam": "Bennette",
                 }
             },
+            "partijIdentificatoren": [
+                {
+                    "anderePartijIdentificator": "string",
+                    "partijIdentificator": {
+                        "codeObjecttype": "niet_natuurlijk_persoon",
+                        "codeSoortObjectId": "rsin",
+                        "objectId": "296648875",
+                        "codeRegister": "hr",
+                    },
+                }
+            ],
         }
 
         response = self.client.put(detail_url, data)
@@ -844,6 +873,16 @@ class PartijTests(APITestCase):
                     "voorvoegselAchternaam": "",
                     "achternaam": "Bennette",
                 },
+            },
+        )
+        self.assertEqual(len(data["partijIdentificatoren"]), 1)
+        self.assertEqual(
+            data["partijIdentificatoren"][0]["partijIdentificator"],
+            {
+                "codeObjecttype": "niet_natuurlijk_persoon",
+                "codeSoortObjectId": "rsin",
+                "objectId": "296648875",
+                "codeRegister": "hr",
             },
         )
 

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -115,15 +115,16 @@ class PartijTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
+        url = "http://testserver/klantinteracties/api/v1"
         self.assertEqual(
             data["partijIdentificatoren"],
             [
                 {
                     "uuid": str(partij_identificator.uuid),
-                    "url": f"http://testserver/klantinteracties/api/v1/partij-identificatoren/{str(partij_identificator.uuid)}",
+                    "url": f"{url}/partij-identificatoren/{str(partij_identificator.uuid)}",
                     "identificeerdePartij": {
                         "uuid": str(partij.uuid),
-                        "url": f"http://testserver/klantinteracties/api/v1/partijen/{str(partij.uuid)}",
+                        "url": f"{url}/partijen/{str(partij.uuid)}",
                     },
                     "anderePartijIdentificator": "society",
                     "partijIdentificator": {

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -2045,7 +2045,7 @@ class PartijIdentificatorTests(APITestCase):
             },
         )
 
-    def test_create_partij_indetificator_invalid_without_identificeerdePartij(self):
+    def test_create_partij_indentificator_invalid_without_identificeerdePartij(self):
         list_url = reverse("klantinteracties:partijidentificator-list")
         data = {
             "anderePartijIdentificator": "anderePartijIdentificator",

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -1946,6 +1946,30 @@ class PartijIdentificatorTests(APITestCase):
             },
         )
 
+    def test_create_partij_indetificator_invalid_without_identificeerdePartij(self):
+        list_url = reverse("klantinteracties:partijidentificator-list")
+        data = {
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"], "invalid")
+        self.assertEqual(response.data["title"], "Invalid input.")
+        self.assertEqual(
+            response.data["invalid_params"][0]["name"], "identificeerdePartij"
+        )
+        self.assertEqual(response.data["invalid_params"][0]["code"], "required")
+        self.assertEqual(
+            response.data["invalid_params"][0]["reason"], "Dit veld is vereist."
+        )
+
     def test_update_partij_indetificator(self):
         partij, partij2 = PartijFactory.create_batch(2)
         partij_identificator = PartijIdentificatorFactory.create(

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -1024,6 +1024,105 @@ class PartijTests(APITestCase):
                 },
             )
 
+    def test_update_partij_partijidentificator_empty_list(self):
+        partij = PartijFactory.create(
+            nummer="1298329191",
+            interne_notitie="interneNotitie",
+            voorkeurs_digitaal_adres=None,
+            voorkeurs_rekeningnummer=None,
+            soort_partij="persoon",
+            indicatie_geheimhouding=True,
+            voorkeurstaal="ndl",
+            indicatie_actief=True,
+            bezoekadres_nummeraanduiding_id="095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            bezoekadres_adresregel1="adres1",
+            bezoekadres_adresregel2="adres2",
+            bezoekadres_adresregel3="adres3",
+            bezoekadres_land="6030",
+            correspondentieadres_nummeraanduiding_id="095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            correspondentieadres_adresregel1="adres1",
+            correspondentieadres_adresregel2="adres2",
+            correspondentieadres_adresregel3="adres3",
+            correspondentieadres_land="6030",
+        )
+        PersoonFactory.create(
+            partij=partij,
+            contactnaam_voorletters="P",
+            contactnaam_voornaam="Phil",
+            contactnaam_voorvoegsel_achternaam="",
+            contactnaam_achternaam="Bozeman",
+        )
+
+        digitaal_adres2 = DigitaalAdresFactory.create()
+        rekeningnummer2 = RekeningnummerFactory.create()
+
+        partij_identificator = PartijIdentificatorFactory.create(
+            partij=partij,
+            partij_identificator_code_objecttype="natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="bsn",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="brp",
+        )
+
+        detail_url = reverse(
+            "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+        self.assertEqual(partij.partijidentificator_set.all().count(), 1)
+        self.assertEqual(
+            data["partijIdentificatoren"][0]["partijIdentificator"],
+            {
+                "codeObjecttype": partij_identificator.partij_identificator_code_objecttype,
+                "codeSoortObjectId": partij_identificator.partij_identificator_code_soort_object_id,
+                "objectId": partij_identificator.partij_identificator_object_id,
+                "codeRegister": partij_identificator.partij_identificator_code_register,
+            },
+        )
+
+        data = {
+            "nummer": "6427834668",
+            "interneNotitie": "changed",
+            "digitaleAdressen": [{"uuid": str(digitaal_adres2.uuid)}],
+            "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
+            "rekeningnummers": [{"uuid": str(rekeningnummer2.uuid)}],
+            "voorkeursRekeningnummer": {"uuid": str(rekeningnummer2.uuid)},
+            "soortPartij": "persoon",
+            "indicatieGeheimhouding": None,
+            "voorkeurstaal": "ger",
+            "indicatieActief": False,
+            "bezoekadres": {
+                "nummeraanduidingId": "f78sd8f-uh45-34km-2o3n-aasdasdasc9g",
+                "adresregel1": "changed",
+                "adresregel2": "changed",
+                "adresregel3": "changed",
+                "land": "3060",
+            },
+            "correspondentieadres": {
+                "nummeraanduidingId": "sd76f7sd-j4nr-a9s8-83ec-sad89f79a7sd",
+                "adresregel1": "changed",
+                "adresregel2": "changed",
+                "adresregel3": "changed",
+                "land": "3060",
+            },
+            "partijIdentificatie": {
+                "contactnaam": {
+                    "voorletters": "V",
+                    "voornaam": "Vincent",
+                    "voorvoegselAchternaam": "",
+                    "achternaam": "Bennette",
+                }
+            },
+            "partijIdentificatoren": [],
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(len(data["partijIdentificatoren"]), 0)
+        self.assertEqual(partij.partijidentificator_set.all().count(), 0)
+
     def test_update_partij_persoon(self):
         partij = PartijFactory.create(
             nummer="1298329191",

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -95,6 +95,47 @@ class PartijTests(APITestCase):
                 data["categorieRelaties"][0]["categorieNaam"], "test-categorie-naam"
             )
 
+        self.assertEqual(data["partijIdentificatoren"], [])
+
+    def test_read_partij_and_partij_identificatoren(self):
+        partij = PartijFactory.create()
+        partij_identificator = PartijIdentificatorFactory.create(
+            partij=partij,
+            partij_identificator_code_objecttype="natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="bsn",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="brp",
+            andere_partij_identificator="society",
+        )
+        detail_url = reverse(
+            "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
+        )
+
+        response = self.client.get(detail_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(
+            data["partijIdentificatoren"],
+            [
+                {
+                    "uuid": str(partij_identificator.uuid),
+                    "url": f"http://testserver/klantinteracties/api/v1/partij-identificatoren/{str(partij_identificator.uuid)}",
+                    "identificeerdePartij": {
+                        "uuid": str(partij.uuid),
+                        "url": f"http://testserver/klantinteracties/api/v1/partijen/{str(partij.uuid)}",
+                    },
+                    "anderePartijIdentificator": "society",
+                    "partijIdentificator": {
+                        "codeObjecttype": "natuurlijk_persoon",
+                        "codeSoortObjectId": "bsn",
+                        "objectId": "296648875",
+                        "codeRegister": "brp",
+                    },
+                }
+            ],
+        )
+
     def test_create_partij(self):
         digitaal_adres, digitaal_adres2 = DigitaalAdresFactory.create_batch(2)
         rekeningnummer, rekeningnummer2 = RekeningnummerFactory.create_batch(2)

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -131,6 +131,17 @@ class PartijTests(APITestCase):
                     "achternaam": "Bozeman",
                 }
             },
+            "partijIdentificatoren": [
+                {
+                    "anderePartijIdentificator": "string",
+                    "partijIdentificator": {
+                        "codeObjecttype": "natuurlijk_persoon",
+                        "codeSoortObjectId": "bsn",
+                        "objectId": "296648875",
+                        "codeRegister": "brp",
+                    },
+                }
+            ],
         }
 
         response = self.client.post(list_url, data)
@@ -174,18 +185,14 @@ class PartijTests(APITestCase):
             },
         )
         self.assertEqual(
-            data["partijIdentificatie"],
+            data["partijIdentificatoren"][0]["partijIdentificator"],
             {
-                "volledigeNaam": "Phil Bozeman",
-                "contactnaam": {
-                    "voorletters": "P",
-                    "voornaam": "Phil",
-                    "voorvoegselAchternaam": "",
-                    "achternaam": "Bozeman",
-                },
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
             },
         )
-
         with self.subTest("create_partij_without_foreignkey_relations"):
             data["nummer"] = "1298329192"
             data["digitaleAdressen"] = []

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -1048,38 +1048,166 @@ class PartijTests(APITestCase):
                 },
             )
 
-    def test_update_partij_partijidentificator_empty_list(self):
-        partij = PartijFactory.create(
-            nummer="1298329191",
-            interne_notitie="interneNotitie",
-            voorkeurs_digitaal_adres=None,
-            voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
-            indicatie_geheimhouding=True,
-            voorkeurstaal="ndl",
-            indicatie_actief=True,
-            bezoekadres_nummeraanduiding_id="095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
-            bezoekadres_adresregel1="adres1",
-            bezoekadres_adresregel2="adres2",
-            bezoekadres_adresregel3="adres3",
-            bezoekadres_land="6030",
-            correspondentieadres_nummeraanduiding_id="095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
-            correspondentieadres_adresregel1="adres1",
-            correspondentieadres_adresregel2="adres2",
-            correspondentieadres_adresregel3="adres3",
-            correspondentieadres_land="6030",
-        )
-        PersoonFactory.create(
-            partij=partij,
-            contactnaam_voorletters="P",
-            contactnaam_voornaam="Phil",
-            contactnaam_voorvoegsel_achternaam="",
-            contactnaam_achternaam="Bozeman",
-        )
-
+    def test_update_partij_partijidentificator(self):
+        partij = PartijFactory.create()
         digitaal_adres2 = DigitaalAdresFactory.create()
-        rekeningnummer2 = RekeningnummerFactory.create()
+        partij_identificator = PartijIdentificatorFactory.create(
+            partij_identificator_code_objecttype="natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="bsn",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="brp",
+        )
+        detail_url = reverse(
+            "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+        self.assertEqual(partij.partijidentificator_set.all().count(), 0)
 
+        data = {
+            "digitaleAdressen": [{"uuid": str(digitaal_adres2.uuid)}],
+            "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
+            "rekeningnummers": [],
+            "voorkeursRekeningnummer": None,
+            "soortPartij": "persoon",
+            "indicatieActief": True,
+            "partijIdentificatoren": [
+                {
+                    "uuid": str(partij_identificator.uuid),
+                },
+            ],
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["partijIdentificatoren"]), 1)
+        self.assertEqual(partij.partijidentificator_set.all().count(), 1)
+
+        self.assertEqual(
+            data["partijIdentificatoren"][0]["partijIdentificator"],
+            {
+                "codeObjecttype": partij_identificator.partij_identificator_code_objecttype,
+                "codeSoortObjectId": partij_identificator.partij_identificator_code_soort_object_id,
+                "objectId": partij_identificator.partij_identificator_object_id,
+                "codeRegister": partij_identificator.partij_identificator_code_register,
+            },
+        )
+
+    def test_update_replace_partij_partijidentificator(self):
+        partij = PartijFactory.create()
+        digitaal_adres2 = DigitaalAdresFactory.create()
+        partij_identificator_1 = PartijIdentificatorFactory.create(
+            partij=partij,
+            partij_identificator_code_objecttype="natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="bsn",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="brp",
+        )
+        partij_identificator_2 = PartijIdentificatorFactory.create(
+            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="rsin",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="hr",
+        )
+        detail_url = reverse(
+            "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+        self.assertEqual(len(data["partijIdentificatoren"]), 1)
+        self.assertEqual(partij.partijidentificator_set.all().count(), 1)
+
+        # Check simple GET
+        self.assertEqual(
+            data["partijIdentificatoren"][0]["partijIdentificator"],
+            {
+                "codeObjecttype": partij_identificator_1.partij_identificator_code_objecttype,
+                "codeSoortObjectId": partij_identificator_1.partij_identificator_code_soort_object_id,
+                "objectId": partij_identificator_1.partij_identificator_object_id,
+                "codeRegister": partij_identificator_1.partij_identificator_code_register,
+            },
+        )
+        # Update with specific partij_identificator (UUID)
+        data = {
+            "digitaleAdressen": [{"uuid": str(digitaal_adres2.uuid)}],
+            "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
+            "rekeningnummers": [],
+            "voorkeursRekeningnummer": None,
+            "soortPartij": "persoon",
+            "indicatieActief": True,
+            "partijIdentificatoren": [
+                {
+                    "uuid": str(partij_identificator_2.uuid),
+                },
+            ],
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["partijIdentificatoren"]), 1)
+        self.assertEqual(partij.partijidentificator_set.all().count(), 1)
+
+        # Check new values
+        self.assertEqual(
+            data["partijIdentificatoren"][0]["partijIdentificator"],
+            {
+                "codeObjecttype": partij_identificator_2.partij_identificator_code_objecttype,
+                "codeSoortObjectId": partij_identificator_2.partij_identificator_code_soort_object_id,
+                "objectId": partij_identificator_2.partij_identificator_object_id,
+                "codeRegister": partij_identificator_2.partij_identificator_code_register,
+            },
+        )
+        partij_identificator_3 = PartijIdentificatorFactory.create(
+            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="rsin",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="hr",
+        )
+
+        # Update with new partij_identificator and specific partij_identificator (UUID)
+        data = {
+            "digitaleAdressen": [{"uuid": str(digitaal_adres2.uuid)}],
+            "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
+            "rekeningnummers": [],
+            "voorkeursRekeningnummer": None,
+            "soortPartij": "persoon",
+            "indicatieActief": True,
+            "partijIdentificatoren": [
+                {
+                    "anderePartijIdentificator": "string",
+                    "partijIdentificator": {
+                        "codeObjecttype": "natuurlijk_persoon",
+                        "codeSoortObjectId": "bsn",
+                        "objectId": "296648875",
+                        "codeRegister": "brp",
+                    },
+                },
+                {
+                    "uuid": str(partij_identificator_3.uuid),
+                },
+            ],
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["partijIdentificatoren"]), 2)
+        self.assertEqual(partij.partijidentificator_set.all().count(), 2)
+        self.assertTrue(
+            str(partij_identificator_3.uuid)
+            in [
+                identificator["uuid"] for identificator in data["partijIdentificatoren"]
+            ]
+        )
+
+    def test_update_partij_partijidentificator_empty_list(self):
+        partij = PartijFactory.create()
+        digitaal_adres2 = DigitaalAdresFactory.create()
         partij_identificator = PartijIdentificatorFactory.create(
             partij=partij,
             partij_identificator_code_objecttype="natuurlijk_persoon",
@@ -1091,6 +1219,7 @@ class PartijTests(APITestCase):
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
+
         response = self.client.get(detail_url)
         data = response.json()
         self.assertEqual(partij.partijidentificator_set.all().count(), 1)
@@ -1105,45 +1234,19 @@ class PartijTests(APITestCase):
         )
 
         data = {
-            "nummer": "6427834668",
-            "interneNotitie": "changed",
             "digitaleAdressen": [{"uuid": str(digitaal_adres2.uuid)}],
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
-            "rekeningnummers": [{"uuid": str(rekeningnummer2.uuid)}],
-            "voorkeursRekeningnummer": {"uuid": str(rekeningnummer2.uuid)},
+            "rekeningnummers": [],
+            "voorkeursRekeningnummer": None,
             "soortPartij": "persoon",
-            "indicatieGeheimhouding": None,
-            "voorkeurstaal": "ger",
-            "indicatieActief": False,
-            "bezoekadres": {
-                "nummeraanduidingId": "f78sd8f-uh45-34km-2o3n-aasdasdasc9g",
-                "adresregel1": "changed",
-                "adresregel2": "changed",
-                "adresregel3": "changed",
-                "land": "3060",
-            },
-            "correspondentieadres": {
-                "nummeraanduidingId": "sd76f7sd-j4nr-a9s8-83ec-sad89f79a7sd",
-                "adresregel1": "changed",
-                "adresregel2": "changed",
-                "adresregel3": "changed",
-                "land": "3060",
-            },
-            "partijIdentificatie": {
-                "contactnaam": {
-                    "voorletters": "V",
-                    "voornaam": "Vincent",
-                    "voorvoegselAchternaam": "",
-                    "achternaam": "Bennette",
-                }
-            },
+            "indicatieActief": True,
             "partijIdentificatoren": [],
         }
 
         response = self.client.put(detail_url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
 
+        data = response.json()
         self.assertEqual(len(data["partijIdentificatoren"]), 0)
         self.assertEqual(partij.partijidentificator_set.all().count(), 0)
 

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -3065,8 +3065,7 @@ components:
         partijIdentificatoren:
           type: array
           items:
-            $ref: '#/components/schemas/PartijIdentificatorForeignkey'
-          readOnly: true
+            $ref: '#/components/schemas/PartijIdentificator'
           description: Partij-identificatoren die hoorde bij deze partij.
         soortPartij:
           allOf:
@@ -3107,7 +3106,6 @@ components:
       - categorieRelaties
       - digitaleAdressen
       - indicatieActief
-      - partijIdentificatoren
       - rekeningnummers
       - soortPartij
       - url
@@ -4755,25 +4753,7 @@ components:
           description: Gegevens die een partij in een basisregistratie of ander extern
             register uniek identificeren.
       required:
-      - identificeerdePartij
       - partijIdentificator
-      - url
-      - uuid
-    PartijIdentificatorForeignkey:
-      type: object
-      properties:
-        uuid:
-          type: string
-          format: uuid
-          description: Unieke (technische) identificatiecode van de partij-identificator.
-        url:
-          type: string
-          format: uri
-          readOnly: true
-          description: De unieke URL van deze partij indentificator binnen deze API.
-          minLength: 1
-          maxLength: 1000
-      required:
       - url
       - uuid
     PartijIdentificatorGroepType:

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -2136,7 +2136,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PartijIdentificator'
-        required: true
       security:
       - tokenAuth: []
       responses:
@@ -2189,7 +2188,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PartijIdentificator'
-        required: true
       security:
       - tokenAuth: []
       responses:
@@ -3066,6 +3064,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PartijIdentificator'
+          nullable: true
           description: Partij-identificatoren die hoorde bij deze partij.
         soortPartij:
           allOf:
@@ -4726,7 +4725,6 @@ components:
         uuid:
           type: string
           format: uuid
-          readOnly: true
           description: Unieke (technische) identificatiecode van de partij-identificator.
         url:
           type: string
@@ -4753,9 +4751,7 @@ components:
           description: Gegevens die een partij in een basisregistratie of ander extern
             register uniek identificeren.
       required:
-      - partijIdentificator
       - url
-      - uuid
     PartijIdentificatorGroepType:
       type: object
       properties:
@@ -5250,7 +5246,6 @@ components:
         uuid:
           type: string
           format: uuid
-          readOnly: true
           description: Unieke (technische) identificatiecode van de partij-identificator.
         url:
           type: string


### PR DESCRIPTION
Fixes #239 and #262

`// GET /partijen`


```jsonc

// POST /partijen
{
    ...
        {
         ...
          "partijIdentificatoren": [
          {
                "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
                "url": "http://example.com",
                "identificeerdePartij": {
                        "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
                        "url": "http://example.com/"
                },
                "anderePartijIdentificator": "string",
                "partijIdentificator": {
                                        "codeObjecttype": "natuurlijk_persoon",
                                        "codeSoortObjectId": "bsn",
                                        "objectId": "string",
                                        "codeRegister": "brp"
                }
           }
        ],
    ...
       }
   ...
}
```




`// POST /partijen` allow to pass a list of `partijIdentificatoren`: 
- `partij_identificator`  or  `UUID`

```jsonc

// POST /partijen
{
    ...
    ...
    # list of partij identificatoren
    "partijIdentificatoren": [
        # create new partij_identificator and attach to partij
        {
            "anderePartijIdentificator": "string",
            "partijIdentificator": {
                "codeObjecttype": "niet_natuurlijk_persoon",
                "codeSoortObjectId": "rsin",
                "objectId": "296648875",
                "codeRegister": "hr",
            },
        },
        # attach existing partij_identificator with UUID to partij
        {
            "uuid": str(partij_identificator.uuid),
        },
    ],
    ...
    ...
}
```

`// PUT /partijen`  allow to pass a list of `partijIdentificatoren`: 
- `partij_identificator` obj  or  `UUID`


// PUT /partijen
3 cases:
```jsonc

# 1 no action is performed
{
    ...
    ...
    # None or not specified key in PUT /partijen
    "partijIdentificatoren": None
    ...
    ...
}

# 2 delete all partijIdentificatoren, because specified a empty list
{
    ...
    ...
    # empty list in PUT /partijen
    "partijIdentificatoren": []
    ...
    ...
}

# 3 delete all partijIdentificatoren and attach new partij_identificator as in POST
{
    ...
    ...
    # list of partij identificatoren
    "partijIdentificatoren": [
        # create new partij_identificator and attach to partij
        {
            "anderePartijIdentificator": "string",
            "partijIdentificator": {
                "codeObjecttype": "niet_natuurlijk_persoon",
                "codeSoortObjectId": "rsin",
                "objectId": "296648875",
                "codeRegister": "hr",
            },
        },
        # attach existing partij_identificator with UUID to partij
        {
            "uuid": str(partij_identificator.uuid),
        },
    ],
    ...
    ...
}
```
 **
For updating `partij-identificatoren`, this is not the right endpoint, because the edpoint `/partij-identificatoren/` remains accessible for their operation.
**