### PR TITLE
[#239] Include PartijIdentificatoren on Partij serializer

### DIFF
--- a/docs/installation/config/env_configuration.rst
+++ b/docs/installation/config/env_configuration.rst
@@ -67,6 +67,7 @@ Content Security Policy
 Optional
 --------
 
+* ``SITE_ID``: The database ID of the site object. You usually won't have to touch this. Defaults to: ``1``.
 * ``DEBUG``: Only set this to ``True`` on a local development environment. Various other security settings are derived from this setting!. Defaults to: ``False``.
 * ``USE_X_FORWARDED_HOST``: whether to grab the domain/host from the X-Forwarded-Host header or not. This header is typically set by reverse proxies (such as nginx, traefik, Apache...). Note: this is a header that can be spoofed and you need to ensure you control it before enabling this. Defaults to: ``False``.
 * ``IS_HTTPS``: Used to construct absolute URLs and controls a variety of security settings. Defaults to the inverse of ``DEBUG``.
@@ -89,7 +90,7 @@ Optional
 * ``NUM_PROXIES``: the number of reverse proxies in front of the application, as an integer. This is used to determine the actual client IP adres. On Kubernetes with an ingress you typically want to set this to 2. Defaults to: ``1``.
 * ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``.
 * ``NOTIFICATIONS_DISABLED``: Indicates whether or not notifications should be sent to the Notificaties API for operations on the API endpoints. Defaults to: ``True``.
-* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``example.com``.
+* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``(empty string)``.
 * ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this.
 * ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``.
 * ``LOG_OUTGOING_REQUESTS_EMIT_BODY``: Whether or not outgoing request bodies should be logged. Defaults to: ``True``.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,8 +16,6 @@ asgiref==3.8.1
     #   django-cors-headers
 asn1crypto==1.5.1
     # via webauthn
-async-timeout==5.0.1
-    # via redis
 attrs==23.2.0
     # via
     #   glom
@@ -240,9 +238,9 @@ mozilla-django-oidc-db==0.22.0
     # via
     #   -r requirements/base.in
     #   open-api-framework
-notifications-api-common==0.7.1
+notifications-api-common==0.7.2
     # via commonground-api-common
-open-api-framework==0.9.4
+open-api-framework==0.9.6
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl
@@ -338,8 +336,6 @@ tornado==6.4.2
     # via flower
 typing-extensions==4.12.2
     # via
-    #   asgiref
-    #   django-solo
     #   mozilla-django-oidc-db
     #   pydantic
     #   pydantic-core

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -33,11 +33,6 @@ asn1crypto==1.5.1
     #   webauthn
 astroid==3.2.4
     # via pylint
-async-timeout==5.0.1
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   redis
 attrs==23.2.0
     # via
     #   -c requirements/base.txt
@@ -382,8 +377,6 @@ elastic-apm==6.23.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
-exceptiongroup==1.2.2
-    # via pytest
 face==20.1.1
     # via
     #   -c requirements/base.txt
@@ -509,12 +502,12 @@ multidict==6.0.5
     # via yarl
 mypy-extensions==1.0.0
     # via black
-notifications-api-common==0.7.1
+notifications-api-common==0.7.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.9.4
+open-api-framework==0.9.6
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -758,12 +751,6 @@ sqlparse==0.5.1
     #   django
 tblib==3.0.0
     # via -r requirements/test-tools.in
-tomli==2.2.1
-    # via
-    #   black
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
     # via pylint
 tornado==6.4.2
@@ -775,10 +762,6 @@ typing-extensions==4.12.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   asgiref
-    #   astroid
-    #   black
-    #   django-solo
     #   faker
     #   mozilla-django-oidc-db
     #   pydantic

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,11 +39,6 @@ astroid==3.2.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pylint
-async-timeout==5.0.1
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   redis
 attrs==23.2.0
     # via
     #   -c requirements/ci.txt
@@ -423,11 +418,6 @@ elastic-apm==6.23.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
-exceptiongroup==1.2.2
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   pytest
 face==20.1.1
     # via
     #   -c requirements/ci.txt
@@ -587,12 +577,12 @@ mypy-extensions==1.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   black
-notifications-api-common==0.7.1
+notifications-api-common==0.7.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.9.4
+open-api-framework==0.9.6
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -913,16 +903,6 @@ tblib==3.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-tomli==2.2.1
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   black
-    #   build
-    #   pip-tools
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
     # via
     #   -c requirements/ci.txt
@@ -937,10 +917,6 @@ typing-extensions==4.12.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   asgiref
-    #   astroid
-    #   black
-    #   django-solo
     #   faker
     #   mozilla-django-oidc-db
     #   pydantic

--- a/src/openklant/components/contactgegevens/api/schema.py
+++ b/src/openklant/components/contactgegevens/api/schema.py
@@ -1,9 +1,21 @@
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
-# TODO: write a propper description
-description = """
-Description WIP.
+description = _(
+    """
+**Warning: Difference between `PUT` and `PATCH`**
+
+Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+but there is a key difference in how they handle required fields:
+
+> The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+If any mandatory field is missing, the update will fail.
+
+> The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+Some mandatory fields can be left out, and the resource will only be updated with the provided data,
+leaving other fields unchanged.
 """
+)
 
 custom_settings = {
     "TITLE": "contactgegevens",

--- a/src/openklant/components/contactgegevens/api/schema.py
+++ b/src/openklant/components/contactgegevens/api/schema.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-description = _(
+DESCRIPTION = _(
     """
 **Warning: Difference between `PUT` and `PATCH`**
 
@@ -19,7 +19,7 @@ leaving other fields unchanged.
 
 custom_settings = {
     "TITLE": "contactgegevens",
-    "DESCRIPTION": description,
+    "DESCRIPTION": DESCRIPTION,
     "VERSION": settings.CONTACTGEGEVENS_API_VERSION,
     "SERVERS": [{"url": "/contactgegevens/api/v1"}],
     "TAGS": [

--- a/src/openklant/components/contactgegevens/api/schema.py
+++ b/src/openklant/components/contactgegevens/api/schema.py
@@ -5,13 +5,13 @@ description = _(
     """
 **Warning: Difference between `PUT` and `PATCH`**
 
-Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+Both `PUT` and `PATCH` methods can be used to update the fields in a resource,
 but there is a key difference in how they handle required fields:
 
-> The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
-If any mandatory field is missing, the update will fail.
+* The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+If any mandatory field is missing, the update will fail. Optional fields are left unchanged if they are not specified.
 
-> The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+* The `PATCH` method, on the other hand, allows you to update only the fields you specify.
 Some mandatory fields can be left out, and the resource will only be updated with the provided data,
 leaving other fields unchanged.
 """

--- a/src/openklant/components/contactgegevens/openapi.yaml
+++ b/src/openklant/components/contactgegevens/openapi.yaml
@@ -6,13 +6,13 @@ info:
 
     **Warning: Difference between `PUT` and `PATCH`**
 
-    Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+    Both `PUT` and `PATCH` methods can be used to update the fields in a resource,
     but there is a key difference in how they handle required fields:
 
-    > The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
-    If any mandatory field is missing, the update will fail.
+    * The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+    If any mandatory field is missing, the update will fail. Optional fields are left unchanged if they are not specified.
 
-    > The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+    * The `PATCH` method, on the other hand, allows you to update only the fields you specify.
     Some mandatory fields can be left out, and the resource will only be updated with the provided data,
     leaving other fields unchanged.
   contact:

--- a/src/openklant/components/contactgegevens/openapi.yaml
+++ b/src/openklant/components/contactgegevens/openapi.yaml
@@ -4,7 +4,17 @@ info:
   version: 1.1.0
   description: |2
 
-    Description WIP.
+    **Warning: Difference between `PUT` and `PATCH`**
+
+    Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+    but there is a key difference in how they handle required fields:
+
+    > The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+    If any mandatory field is missing, the update will fail.
+
+    > The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+    Some mandatory fields can be left out, and the resource will only be updated with the provided data,
+    leaving other fields unchanged.
   contact:
     email: standaarden.ondersteuning@vng.nl
     url: https://zaakgerichtwerken.vng.cloud

--- a/src/openklant/components/klantinteracties/admin/partijen.py
+++ b/src/openklant/components/klantinteracties/admin/partijen.py
@@ -43,6 +43,7 @@ class PartijIdentificatorAdminForm(forms.ModelForm):
             code_soort_object_id=cleaned_data[
                 "partij_identificator_code_soort_object_id"
             ],
+            instance=self.instance if self.instance and self.instance.pk else None,
             sub_identificator_van=cleaned_data["sub_identificator_van"],
         )()
 

--- a/src/openklant/components/klantinteracties/api/schema.py
+++ b/src/openklant/components/klantinteracties/api/schema.py
@@ -15,13 +15,13 @@ description = _(
     """
 **Warning: Difference between `PUT` and `PATCH`**
 
-Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+Both `PUT` and `PATCH` methods can be used to update the fields in a resource,
 but there is a key difference in how they handle required fields:
 
-> The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
-If any mandatory field is missing, the update will fail.
+* The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+If any mandatory field is missing, the update will fail. Optional fields are left unchanged if they are not specified.
 
-> The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+* The `PATCH` method, on the other hand, allows you to update only the fields you specify.
 Some mandatory fields can be left out, and the resource will only be updated with the provided data,
 leaving other fields unchanged.
 """
@@ -30,10 +30,9 @@ partijen_description = _(
     """
 **Atomicity in Partij and PartijIdentificator**
 
-Starting from version **2.7.0**, the `Partij` endpoint has been modified to handle
-`PartijIdentificator` objects more effectively,
+The `Partij` endpoint handles `PartijIdentificator` objects more effectively,
 allowing them to be processed within the same request.
-This ensures that both entities are handled atomically, preventing incomplete,
+This ensures that both entities are handled atomically, preventing incompleteness,
 and offering better control over the uniqueness of `PartijIdentificator` objects.
 
 For `POST`, `PATCH`, and `PUT` requests for `Partij`,
@@ -47,11 +46,11 @@ of the parent `Partij`, because it is automatically assigned.
     - If the **UUID** is provided in the `PartijIdentificator` object,
     the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
     applying the provided data and linking the parent `Partij` to the new one created.
-    - If the **UUID** is **not** specified, the system will create a new resource
-    for the `PartijIdentificator` respecting all uniqueness constraints.
+    - If the **UUID** is **not** specified, the system will create a new
+    `PartijIdentificator` instance respecting all uniqueness constraints.
 - `PATCH` or `PUT` requests:
     - If the **UUID** is provided in the `PartijIdentificator` object,
-    the system will update the specified resource with the new data.
+    the system will update the specified instance with the new data.
     - If the **UUID** is **not** specified, the system will `DELETE` all `PartijIdentificator`
     objects related to the parent and `CREATE` new ones with the passed data.
 """

--- a/src/openklant/components/klantinteracties/api/schema.py
+++ b/src/openklant/components/klantinteracties/api/schema.py
@@ -8,10 +8,7 @@ from openklant.components.klantinteracties.kanalen import (
     KANAAL_PARTIJ,
 )
 
-# TODO: write a propper description
-description = """
-Description WIP.
-description = _(
+DESCRIPTION = _(
     """
 **Warning: Difference between `PUT` and `PATCH`**
 
@@ -26,8 +23,36 @@ Some mandatory fields can be left out, and the resource will only be updated wit
 leaving other fields unchanged.
 """
 )
-partijen_description = _(
+PARTIJ_IDENTIFICATOR_DESCRIPTION_CREATE = _(
     """
+**Warnings:**
+
+Handles `partijIdentificatoren` creation with atomicity guarantees.
+
+- If the `UUID` is provided in the `PartijIdentificator` object,
+the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
+applying the provided data and linking the parent `Partij` to the new one created.
+- If the `UUID` is **not** specified, the system will create a new
+`PartijIdentificator` instance respecting all uniqueness constraints.
+    """
+)
+
+PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE = _(
+    """
+**Warnings:**
+
+Handles `partijIdentificatoren` updates with atomicity guarantees.
+
+- If the `UUID` is provided in the `PartijIdentificator` object,
+the system will update the specified instance with the new data.
+- If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator`
+objects related to the parent and `CREATE` new ones with the new passed data.
+    """
+)
+
+PARTIJEN_DESCRIPTION = (
+    _(
+        """
 **Atomicity in Partij and PartijIdentificator**
 
 The `Partij` endpoint handles `PartijIdentificator` objects more effectively,
@@ -37,28 +62,15 @@ and offering better control over the uniqueness of `PartijIdentificator` objects
 
 For `POST`, `PATCH`, and `PUT` requests for `Partij`,
 it is possible to send a list of `PartijIdentificator` objects.
-
-**Warnings:**
-
-- In all requests, `PartijIdentificator` objects should not contain the **UUID**
-of the parent `Partij`, because it is automatically assigned.
-- `POST` request:
-    - If the **UUID** is provided in the `PartijIdentificator` object,
-    the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
-    applying the provided data and linking the parent `Partij` to the new one created.
-    - If the **UUID** is **not** specified, the system will create a new
-    `PartijIdentificator` instance respecting all uniqueness constraints.
-- `PATCH` or `PUT` requests:
-    - If the **UUID** is provided in the `PartijIdentificator` object,
-    the system will update the specified instance with the new data.
-    - If the **UUID** is **not** specified, the system will `DELETE` all `PartijIdentificator`
-    objects related to the parent and `CREATE` new ones with the passed data.
 """
+    )
+    + notification_documentation(KANAAL_PARTIJ)
 )
+
 
 custom_settings = {
     "TITLE": "klantinteracties",
-    "DESCRIPTION": description,
+    "DESCRIPTION": DESCRIPTION,
     "VERSION": settings.KLANTINTERACTIES_API_VERSION,
     "SERVERS": [{"url": "/klantinteracties/api/v1"}],
     "TAGS": [
@@ -80,7 +92,7 @@ custom_settings = {
             "name": "partijen",
             "description": f"{notification_documentation(KANAAL_PARTIJ)}",
         },
-        {"name": "partijen", "description": partijen_description},
+        {"name": "partijen", "description": PARTIJEN_DESCRIPTION},
         {"name": "rekeningnummers"},
         {"name": "vertegenwoordigingen"},
     ],

--- a/src/openklant/components/klantinteracties/api/schema.py
+++ b/src/openklant/components/klantinteracties/api/schema.py
@@ -29,11 +29,11 @@ PARTIJ_IDENTIFICATOR_DESCRIPTION_CREATE = _(
 
 Handles `partijIdentificatoren` creation with atomicity guarantees.
 
-- If the `UUID` is provided in the `PartijIdentificator` object,
-the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
-applying the provided data and linking the parent `Partij` to the updated `PartijIdentificator`.
+- If the `UUID` is provided in the `partijIdentificator` object,
+the endpoint will treat it as an update operation for the existing `partijIdentificator`,
+applying the provided data and linking the parent `Partij` to the updated `partijIdentificator`.
 - If the `UUID` is **NOT** specified, the system will create a new
-`PartijIdentificator` instance respecting all uniqueness constraints.
+`partijIdentificator` instance respecting all uniqueness constraints.
 
 **Example:**
 
@@ -62,8 +62,39 @@ applying the provided data and linking the parent `Partij` to the updated `Parti
 ```
 
 
-In this case, the `PartijIdentificator` with the specified `UUID` is updated and attached to the parent `Partij`,
- while the `PartijIdentificator` without a `UUID` is created and attached to the parent `Partij`.
+In this case, the `partijIdentificator` with the specified `UUID` is updated and attached to the parent `Partij`,
+ while the `partijIdentificator` without a `UUID` is created and attached to the parent `Partij`.
+
+**Warnings:**
+
+If you want to create a `partijIdentificator` with `vestigingsnummer`,
+you must first ensure that a `partijIdentificator`
+with a `kvk_nummer` already exists to assign it at the `sub_identificator_van`.
+
+**Example:**
+
+```json
+{
+  "partijIdentificatoren": [
+      {
+          "sub_identificator_van": {"uuid": "598ffc4d-737e-49a5-b5e0-cbc438a30cb5"},
+          "partijIdentificator": {
+              "codeObjecttype": "vestiging",
+              "codeSoortObjectId": "vestigingsnummer",
+              "objectId": "string",
+              "codeRegister": "hr",
+          },
+      }
+  ],
+}
+```
+
+Or, to comply with the uniqueness constraints, you must first make a `POST` request
+ to create the `partijIdentificator` with `kvk_nummer`,
+and then send a `PUT` or `PATCH` request to update the list of `partijIdentificatoren`
+ by adding the `partijIdentificator` with `vestigingsnummer`.
+See the documentation for `PUT` and `PATCH` requests in the corresponding section.
+
 """
 )
 
@@ -73,10 +104,11 @@ PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE = _(
 
 Handles `partijIdentificatoren` updates with atomicity guarantees.
 
-- If the `UUID` is specified in the `PartijIdentificator` object,
+- If the `UUID` is specified in the `partijIdentificator` object,
  the system will update the corresponding instance with the new data.
 - If the `UUID` is **NOT** specified, the system will `DELETE` all `partijIdentificatoren`
 objects related to the parent and `CREATE` new ones using the provided data.
+This means that any `partijIdentificatoren` **not included** in the list new data will also be deleted.
 
 **Example:**
 
@@ -104,9 +136,13 @@ objects related to the parent and `CREATE` new ones using the provided data.
 }
 ```
 
-In this case, all `partijIdentificatoren` without a specified `UUID` are deleted,
-a new one is created due to the absence of a `UUID`, and the data for the `PartijIdentificator`
-with the specified `UUID` is then updated.
+In this case, assuming an initial state with 3 `partijIdentificatoren` for the current `Partij`,
+ the system will perform the following operations:
+  - All initial `partijIdentificatoren` not included in the list, as well as those
+  without a specified `UUID`, will be deleted.
+  - `partijIdentificator` with `codeSoortObjectId` = `rsin`, will be updated with the new data provided
+  - All other `partijIdentificatoren` without a specified `UUID` will be created.
+
 """
 )
 
@@ -115,13 +151,13 @@ PARTIJEN_DESCRIPTION = (
         """
 **Atomicity in Partij and PartijIdentificator**
 
-The `Partij` endpoint handles `PartijIdentificator` objects more effectively,
+The `Partij` endpoint handles `partijIdentificator` objects more effectively,
 allowing them to be processed within the same request.
 This ensures that both entities are handled atomically, preventing incompleteness,
-and offering better control over the uniqueness of `PartijIdentificator` objects.
+and offering better control over the uniqueness of `partijIdentificator` objects.
 
 For `POST`, `PATCH`, and `PUT` requests for `Partij`,
-it is possible to send a list of `PartijIdentificator` objects.
+it is possible to send a list of `partijIdentificator` objects.
 
 
 """

--- a/src/openklant/components/klantinteracties/api/schema.py
+++ b/src/openklant/components/klantinteracties/api/schema.py
@@ -62,6 +62,8 @@ and offering better control over the uniqueness of `PartijIdentificator` objects
 
 For `POST`, `PATCH`, and `PUT` requests for `Partij`,
 it is possible to send a list of `PartijIdentificator` objects.
+
+
 """
     )
     + notification_documentation(KANAAL_PARTIJ)
@@ -88,10 +90,6 @@ custom_settings = {
         {"name": "klanten contacten"},
         {"name": "onderwerpobjecten"},
         {"name": "partij-identificatoren"},
-        {
-            "name": "partijen",
-            "description": f"{notification_documentation(KANAAL_PARTIJ)}",
-        },
         {"name": "partijen", "description": PARTIJEN_DESCRIPTION},
         {"name": "rekeningnummers"},
         {"name": "vertegenwoordigingen"},

--- a/src/openklant/components/klantinteracties/api/schema.py
+++ b/src/openklant/components/klantinteracties/api/schema.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from notifications_api_common.utils import notification_documentation
 
@@ -10,7 +11,51 @@ from openklant.components.klantinteracties.kanalen import (
 # TODO: write a propper description
 description = """
 Description WIP.
+description = _(
+    """
+**Warning: Difference between `PUT` and `PATCH`**
+
+Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+but there is a key difference in how they handle required fields:
+
+> The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+If any mandatory field is missing, the update will fail.
+
+> The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+Some mandatory fields can be left out, and the resource will only be updated with the provided data,
+leaving other fields unchanged.
 """
+)
+partijen_description = _(
+    """
+**Atomicity in Partij and PartijIdentificator**
+
+Starting from version **2.7.0**, the `Partij` endpoint has been modified to handle
+`PartijIdentificator` objects more effectively,
+allowing them to be processed within the same request.
+This ensures that both entities are handled atomically, preventing incomplete,
+and offering better control over the uniqueness of `PartijIdentificator` objects.
+
+For `POST`, `PATCH`, and `PUT` requests for `Partij`,
+it is possible to send a list of `PartijIdentificator` objects.
+
+**Warnings:**
+
+- In all requests, `PartijIdentificator` objects should not contain the **UUID**
+of the parent `Partij`, because it is automatically assigned.
+- `POST` request:
+    - If the **UUID** is provided in the `PartijIdentificator` object,
+    the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
+    applying the provided data and linking the parent `Partij` to the new one created.
+    - If the **UUID** is **not** specified, the system will create a new resource
+    for the `PartijIdentificator` respecting all uniqueness constraints.
+- `PATCH` or `PUT` requests:
+    - If the **UUID** is provided in the `PartijIdentificator` object,
+    the system will update the specified resource with the new data.
+    - If the **UUID** is **not** specified, the system will `DELETE` all `PartijIdentificator`
+    objects related to the parent and `CREATE` new ones with the passed data.
+"""
+)
 
 custom_settings = {
     "TITLE": "klantinteracties",
@@ -36,6 +81,7 @@ custom_settings = {
             "name": "partijen",
             "description": f"{notification_documentation(KANAAL_PARTIJ)}",
         },
+        {"name": "partijen", "description": partijen_description},
         {"name": "rekeningnummers"},
         {"name": "vertegenwoordigingen"},
     ],

--- a/src/openklant/components/klantinteracties/api/schema.py
+++ b/src/openklant/components/klantinteracties/api/schema.py
@@ -31,10 +31,40 @@ Handles `partijIdentificatoren` creation with atomicity guarantees.
 
 - If the `UUID` is provided in the `PartijIdentificator` object,
 the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
-applying the provided data and linking the parent `Partij` to the new one created.
-- If the `UUID` is **not** specified, the system will create a new
+applying the provided data and linking the parent `Partij` to the updated `PartijIdentificator`.
+- If the `UUID` is **NOT** specified, the system will create a new
 `PartijIdentificator` instance respecting all uniqueness constraints.
-    """
+
+**Example:**
+
+```json
+{
+  "partijIdentificatoren": [
+    {
+      "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+      "partijIdentificator": {
+        "codeObjecttype": "niet_natuurlijk_persoon",
+        "codeSoortObjectId": "rsin",
+        "objectId": "string",
+        "codeRegister": "hr"
+      }
+    },
+    {
+      "partijIdentificator": {
+        "codeObjecttype": "natuurlijk_persoon",
+        "codeSoortObjectId": "bsn",
+        "objectId": "string",
+        "codeRegister": "brp"
+      }
+    }
+  ]
+}
+```
+
+
+In this case, the `PartijIdentificator` with the specified `UUID` is updated and attached to the parent `Partij`,
+ while the `PartijIdentificator` without a `UUID` is created and attached to the parent `Partij`.
+"""
 )
 
 PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE = _(
@@ -43,11 +73,41 @@ PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE = _(
 
 Handles `partijIdentificatoren` updates with atomicity guarantees.
 
-- If the `UUID` is provided in the `PartijIdentificator` object,
-the system will update the specified instance with the new data.
-- If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator`
-objects related to the parent and `CREATE` new ones with the new passed data.
-    """
+- If the `UUID` is specified in the `PartijIdentificator` object,
+ the system will update the corresponding instance with the new data.
+- If the `UUID` is **NOT** specified, the system will `DELETE` all `partijIdentificatoren`
+objects related to the parent and `CREATE` new ones using the provided data.
+
+**Example:**
+
+```json
+{
+  "partijIdentificatoren": [
+    {
+      "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+      "partijIdentificator": {
+        "codeObjecttype": "niet_natuurlijk_persoon",
+        "codeSoortObjectId": "rsin",
+        "objectId": "string",
+        "codeRegister": "hr"
+      }
+    },
+    {
+      "partijIdentificator": {
+        "codeObjecttype": "natuurlijk_persoon",
+        "codeSoortObjectId": "bsn",
+        "objectId": "string",
+        "codeRegister": "brp"
+      }
+    }
+  ]
+}
+```
+
+In this case, all `partijIdentificatoren` without a specified `UUID` are deleted,
+a new one is created due to the absence of a `UUID`, and the data for the `PartijIdentificator`
+with the specified `UUID` is then updated.
+"""
 )
 
 PARTIJEN_DESCRIPTION = (

--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -603,25 +603,17 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
 
     def validate_partij_identificatoren(self, attrs):
         if attrs:
-            if (
-                len(
-                    Counter(
-                        item["partij"] for item in attrs if item["partij"] is not None
-                    )
-                )
-                > 0
-            ):
+            if any(item["partij"] is not None for item in attrs):
                 raise serializers.ValidationError(
                     {
                         "identificeerdePartij": _(
                             "Het veld `identificeerde_partij` wordt automatisch ingesteld en"
-                            " hoeft niet te worden opgegeven."
+                            " dient niet te worden opgegeven."
                         )
                     },
                     code="invalid",
                 )
-
-            uuid_list = [item["uuid"] for item in attrs if "uuid" in attrs]
+            uuid_list = [item["uuid"] for item in attrs if "uuid" in item]
             if uuid_list and max(Counter(uuid_list).values()) > 1:
                 raise serializers.ValidationError(
                     {
@@ -655,6 +647,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
                 partij_identificator_serializer.validated_data
             )
 
+    @handle_db_exceptions
     @transaction.atomic
     def update(self, instance, validated_data):
         method = self.context.get("request").method
@@ -831,6 +824,7 @@ class PartijSerializer(NestedGegevensGroepMixin, PolymorphicSerializer):
 
         return partij
 
+    @handle_db_exceptions
     @transaction.atomic
     def create(self, validated_data):
         partij_identificatie = validated_data.pop("partij_identificatie", None)

--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -444,23 +444,14 @@ class PartijIdentificatorSerializer(
 
         return super().validate(attrs)
 
-    def validate_partij(self, partij):
-        if not partij:
-            raise serializers.ValidationError(
-                {"identificeerdePartij": _("Dit veld is vereist.")},
-                code="required",
-            )
-
     @handle_db_exceptions
     @transaction.atomic
     def update(self, instance, validated_data):
-        self.validate_partij(validated_data["partij"])
         return super().update(instance, validated_data)
 
     @handle_db_exceptions
     @transaction.atomic
     def create(self, validated_data):
-        self.validate_partij(validated_data["partij"])
         return super().create(validated_data)
 
 

--- a/src/openklant/components/klantinteracties/api/serializers/partijen.py
+++ b/src/openklant/components/klantinteracties/api/serializers/partijen.py
@@ -436,6 +436,7 @@ class PartijIdentificatorSerializer(
             )
             PartijIdentificatorUniquenessValidator(
                 code_soort_object_id=partij_identificator["code_soort_object_id"],
+                instance=self.instance if self.instance else None,
                 sub_identificator_van=sub_identificator_van,
             )()
 

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_categorie.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_categorie.py
@@ -1,0 +1,252 @@
+import datetime
+
+from rest_framework import status
+from vng_api_common.tests import reverse
+
+from openklant.components.klantinteracties.models.tests.factories.partijen import (
+    CategorieFactory,
+    CategorieRelatieFactory,
+    PartijFactory,
+)
+from openklant.components.token.tests.api_testcase import APITestCase
+
+
+class CategorieRelatieTests(APITestCase):
+    def test_list_categorie_relatie(self):
+        list_url = reverse("klantinteracties:categorierelatie-list")
+        CategorieRelatieFactory.create_batch(2)
+
+        response = self.client.get(list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_read_categorie_relatie(self):
+        categorie_relatie = CategorieRelatieFactory.create()
+        detail_url = reverse(
+            "klantinteracties:categorierelatie-detail",
+            kwargs={"uuid": str(categorie_relatie.uuid)},
+        )
+
+        response = self.client.get(detail_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["url"], "http://testserver" + detail_url)
+
+    def test_create_categorie_relatie(self):
+        list_url = reverse("klantinteracties:categorierelatie-list")
+        partij = PartijFactory.create()
+        categorie = CategorieFactory.create(naam="naam")
+        data = {
+            "partij": {"uuid": str(partij.uuid)},
+            "categorie": {"uuid": str(categorie.uuid)},
+            "beginDatum": "2024-01-11",
+            "eindDatum": "2024-01-12",
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["partij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["categorie"]["uuid"], str(categorie.uuid))
+        self.assertEqual(data["categorie"]["naam"], "naam")
+        self.assertEqual(data["beginDatum"], "2024-01-11")
+        self.assertEqual(data["eindDatum"], "2024-01-12")
+
+        with self.subTest("fill_begin_datum_when_empty_with_todays_date"):
+            today = datetime.datetime.today().strftime("%Y-%m-%d")
+            data["beginDatum"] = None
+
+            response = self.client.post(list_url, data)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            data = response.json()
+
+            self.assertEqual(data["beginDatum"], today)
+
+    def test_update_categorie_relatie(self):
+        partij, partij2 = PartijFactory.create_batch(2)
+        categorie, categorie2 = CategorieFactory.create_batch(2)
+        categorie_relatie = CategorieRelatieFactory.create(
+            partij=partij,
+            categorie=categorie,
+            begin_datum="2024-01-11",
+            eind_datum=None,
+        )
+        detail_url = reverse(
+            "klantinteracties:categorierelatie-detail",
+            kwargs={"uuid": str(categorie_relatie.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["partij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["categorie"]["uuid"], str(categorie.uuid))
+        self.assertEqual(data["categorie"]["naam"], categorie.naam)
+        self.assertEqual(data["beginDatum"], "2024-01-11")
+        self.assertEqual(data["eindDatum"], None)
+
+        data = {
+            "partij": {"uuid": str(partij2.uuid)},
+            "categorie": {"uuid": str(categorie2.uuid)},
+            "beginDatum": "2024-01-12",
+            "eindDatum": "2024-01-14",
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["partij"]["uuid"], str(partij2.uuid))
+        self.assertEqual(data["categorie"]["uuid"], str(categorie2.uuid))
+        self.assertEqual(data["categorie"]["naam"], categorie2.naam)
+        self.assertEqual(data["beginDatum"], "2024-01-12")
+        self.assertEqual(data["eindDatum"], "2024-01-14")
+
+    def test_update_partial_categorie_relatie(self):
+        partij = PartijFactory.create()
+        categorie = CategorieFactory.create(naam="naam")
+        categorie_relatie = CategorieRelatieFactory.create(
+            partij=partij,
+            categorie=categorie,
+            begin_datum="2024-01-11",
+            eind_datum=None,
+        )
+        detail_url = reverse(
+            "klantinteracties:categorierelatie-detail",
+            kwargs={"uuid": str(categorie_relatie.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["partij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["categorie"]["uuid"], str(categorie.uuid))
+        self.assertEqual(data["categorie"]["naam"], categorie.naam)
+        self.assertEqual(data["beginDatum"], "2024-01-11")
+        self.assertEqual(data["eindDatum"], None)
+
+        data = {
+            "eindDatum": "2024-01-14",
+        }
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["partij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["categorie"]["uuid"], str(categorie.uuid))
+        self.assertEqual(data["categorie"]["naam"], "naam")
+        self.assertEqual(data["beginDatum"], "2024-01-11")
+        self.assertEqual(data["eindDatum"], "2024-01-14")
+
+    def test_destroy_categorie_relatie(self):
+        categorie_relatie = CategorieRelatieFactory.create()
+        detail_url = reverse(
+            "klantinteracties:categorierelatie-detail",
+            kwargs={"uuid": str(categorie_relatie.uuid)},
+        )
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        list_url = reverse("klantinteracties:categorierelatie-list")
+        response = self.client.get(list_url)
+        data = response.json()
+        self.assertEqual(data["count"], 0)
+
+
+class CategorieTests(APITestCase):
+    def test_list_categorie(self):
+        list_url = reverse("klantinteracties:categorie-list")
+        CategorieFactory.create_batch(2)
+
+        response = self.client.get(list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_read_categorie(self):
+        partij_identificator = CategorieFactory.create()
+        detail_url = reverse(
+            "klantinteracties:categorie-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.get(detail_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["url"], "http://testserver" + detail_url)
+
+    def test_create_categorie(self):
+        list_url = reverse("klantinteracties:categorie-list")
+        data = {
+            "naam": "naam",
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["naam"], "naam")
+
+    def test_update_categorie(self):
+        categorie = CategorieFactory.create(naam="naam")
+
+        detail_url = reverse(
+            "klantinteracties:categorie-detail",
+            kwargs={"uuid": str(categorie.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["naam"], "naam")
+
+        data = {
+            "naam": "changed",
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["naam"], "changed")
+
+    def test_partial_update_categorie(self):
+        categorie = CategorieFactory.create(
+            naam="naam",
+        )
+
+        detail_url = reverse(
+            "klantinteracties:categorie-detail",
+            kwargs={"uuid": str(categorie.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["naam"], "naam")
+
+        data = {"naam": "changed"}
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["naam"], "changed")
+
+    def test_destroy_categorie(self):
+        categorie = CategorieFactory.create()
+        detail_url = reverse(
+            "klantinteracties:categorie-detail",
+            kwargs={"uuid": str(categorie.uuid)},
+        )
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        list_url = reverse("klantinteracties:categorie-list")
+        response = self.client.get(list_url)
+        data = response.json()
+        self.assertEqual(data["count"], 0)

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_categorie.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_categorie.py
@@ -3,7 +3,7 @@ import datetime
 from rest_framework import status
 from vng_api_common.tests import reverse
 
-from openklant.components.klantinteracties.models.tests.factories.partijen import (
+from openklant.components.klantinteracties.models.tests.factories import (
     CategorieFactory,
     CategorieRelatieFactory,
     PartijFactory,

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
@@ -8,23 +8,19 @@ from openklant.components.klantinteracties.models.partijen import (
     Partij,
     PartijIdentificator,
 )
-from openklant.components.klantinteracties.models.tests.factories.digitaal_adres import (
-    DigitaalAdresFactory,
-)
-from openklant.components.klantinteracties.models.tests.factories.partijen import (
+from openklant.components.klantinteracties.models.tests.factories import (
     BsnPartijIdentificatorFactory,
     CategorieFactory,
     CategorieRelatieFactory,
     ContactpersoonFactory,
+    DigitaalAdresFactory,
     KvkNummerPartijIdentificatorFactory,
     OrganisatieFactory,
     PartijFactory,
     PersoonFactory,
+    RekeningnummerFactory,
     VertegenwoordigdenFactory,
     VestigingsnummerPartijIdentificatorFactory,
-)
-from openklant.components.klantinteracties.models.tests.factories.rekeningnummer import (
-    RekeningnummerFactory,
 )
 from openklant.components.token.tests.api_testcase import APITestCase
 

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
@@ -2598,6 +2598,18 @@ class NestedPartijIdentificatorTests(APITestCase):
 
         self.assertEqual(Partij.objects.all().count(), 1)
 
+        # PATC and PUT allow to pass identificeerdePartij
+        data["soortPartij"] = "organisatie"
+        detail_url = reverse(
+            "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
+        )
+        # PUT same data received from POST
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["partijIdentificatoren"]), 1)
+        self.assertEqual(response_data["soortPartij"], "organisatie")
+
     def test_invalid_create_partij_identificator_globally_uniqueness(self):
         digitaal_adres = DigitaalAdresFactory.create()
         rekeningnummer = RekeningnummerFactory.create()

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_partij_identificator.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_partij_identificator.py
@@ -1,0 +1,917 @@
+from rest_framework import status
+from vng_api_common.tests import get_validation_errors, reverse, reverse_lazy
+
+from openklant.components.klantinteracties.models.partijen import PartijIdentificator
+from openklant.components.klantinteracties.models.tests.factories.partijen import (
+    BsnPartijIdentificatorFactory,
+    KvkNummerPartijIdentificatorFactory,
+    PartijFactory,
+    PartijIdentificatorFactory,
+    VestigingsnummerPartijIdentificatorFactory,
+)
+from openklant.components.token.tests.api_testcase import APITestCase
+
+
+class PartijIdentificatorTests(APITestCase):
+
+    def test_list(self):
+        list_url = reverse("klantinteracties:partijidentificator-list")
+        partij = PartijFactory.create()
+        BsnPartijIdentificatorFactory.create(partij=partij)
+        PartijIdentificator.objects.create(
+            partij=partij,
+            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
+            partij_identificator_code_soort_object_id="rsin",
+            partij_identificator_object_id="296648875",
+            partij_identificator_code_register="hr",
+        )
+        response = self.client.get(list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_read(self):
+        partij_identificator = PartijIdentificatorFactory.create()
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.get(detail_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["url"], "http://testserver" + detail_url)
+
+    def test_create(self):
+        list_url = reverse("klantinteracties:partijidentificator-list")
+        partij = PartijFactory.create()
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "anderePartijIdentificator")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        )
+
+    def test_update(self):
+        partij, partij2 = PartijFactory.create_batch(2)
+        partij_identificator = BsnPartijIdentificatorFactory.create(
+            partij=partij,
+            andere_partij_identificator="anderePartijIdentificator",
+        )
+
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "anderePartijIdentificator")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        )
+
+        data = {
+            "identificeerdePartij": {"uuid": str(partij2.uuid)},
+            "anderePartijIdentificator": "changed",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(partij2.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "changed")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        )
+
+    def test_update_partial(self):
+        partij = PartijFactory.create()
+        partij_identificator = BsnPartijIdentificatorFactory.create(
+            partij=partij,
+            andere_partij_identificator="anderePartijIdentificator",
+        )
+
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "anderePartijIdentificator")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        )
+
+        data = {
+            "anderePartijIdentificator": "changed",
+        }
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "changed")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        )
+
+    def test_update_only_required(self):
+        # partij_identificator is required
+        partij = PartijFactory.create()
+        partij_identificator = BsnPartijIdentificatorFactory.create(
+            partij=partij,
+            andere_partij_identificator="anderePartijIdentificator",
+        )
+
+        data = {
+            "andere_partij_identificator": "test",
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "partijIdentificator")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "changed",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "123456782",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "changed")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "123456782",
+                "codeRegister": "brp",
+            },
+        )
+
+    def test_destroy(self):
+        partij_identificator = PartijIdentificatorFactory.create()
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        list_url = reverse("klantinteracties:partijidentificator-list")
+        response = self.client.get(list_url)
+        data = response.json()
+        self.assertEqual(data["count"], 0)
+
+    def test_invalid_choices_partij_identificator(self):
+        url = reverse("klantinteracties:partijidentificator-list")
+        partij = PartijFactory.create()
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "test",
+                "codeSoortObjectId": "test",
+                "objectId": "",
+                "codeRegister": "test",
+            },
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"], "invalid")
+        self.assertEqual(response.data["title"], "Invalid input.")
+        self.assertEqual(len(response.data["invalid_params"]), 3)
+        self.assertEqual(
+            {item["name"] for item in response.data["invalid_params"]},
+            {
+                "partijIdentificator.codeObjecttype",
+                "partijIdentificator.codeRegister",
+                "partijIdentificator.codeSoortObjectId",
+            },
+        )
+
+    def test_invalid_validation_partij_identificator_code_objecttype(self):
+        url = reverse("klantinteracties:partijidentificator-list")
+        partij = PartijFactory.create()
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "niet_natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "partijIdentificatorCodeObjecttype")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            "voor `codeRegister` brp zijn alleen deze waarden toegestaan: ['natuurlijk_persoon']",
+        )
+
+    def test_invalid_validation_partij_identificator_code_soort_object_id(self):
+        url = reverse("klantinteracties:partijidentificator-list")
+        partij = PartijFactory.create()
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "kvk_nummer",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "partijIdentificatorCodeSoortObjectId")
+        self.assertEqual(error["code"], "invalid")
+
+        self.assertEqual(
+            error["reason"],
+            "voor `codeObjecttype` natuurlijk_persoon zijn alleen deze waarden toegestaan: ['bsn', 'overig']",
+        )
+
+    def test_invalid_validation_partij_identificator_object_id(self):
+        url = reverse("klantinteracties:partijidentificator-list")
+        partij = PartijFactory.create()
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "12",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "partijIdentificatorObjectId")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            "Deze waarde is ongeldig, reden: Waarde moet 9 tekens lang zijn",
+        )
+
+    def test_invalid_create_empty_partij_identificator(self):
+        # all partij_identificator fields required
+        partij = PartijFactory.create()
+        list_url = reverse("klantinteracties:partijidentificator-list")
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {},
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data["invalid_params"]), 4)
+        get_validation_errors(response, "partijIdentificator.objectId")
+        get_validation_errors(response, "partijIdentificator.codeSoortObjectId")
+        get_validation_errors(response, "partijIdentificator.codeObjecttype")
+        get_validation_errors(response, "partijIdentificator.codeRegister")
+
+    def test_invalid_create_partial_partij_identificator(self):
+        # all partij_identificator fields required
+        partij = PartijFactory.create()
+        list_url = reverse("klantinteracties:partijidentificator-list")
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "partijIdentificator.objectId")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+        self.assertEqual(PartijIdentificator.objects.all().count(), 0)
+
+    def test_invalid_update_partial_partij_identificator(self):
+        # all partij_identificator values are required
+        partij = PartijFactory.create()
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=partij)
+        data = {
+            "identificeerdePartij": None,
+            "partijIdentificator": {},
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "partijIdentificator.objectId")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+        self.assertEqual(PartijIdentificator.objects.all().count(), 1)
+
+        data = {
+            "identificeerdePartij": None,
+            "partijIdentificator": {
+                "codeObjecttype": "niet_natuurlijk_persoon",
+                "codeSoortObjectId": "rsin",
+                "codeRegister": "brp",
+            },
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "partijIdentificator.objectId")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+        self.assertEqual(PartijIdentificator.objects.all().count(), 1)
+
+
+class PartijIdentificatorUniquenessTests(APITestCase):
+    list_url = reverse_lazy("klantinteracties:partijidentificator-list")
+
+    def setUp(self):
+        self.partij = PartijFactory.create()
+        super().setUp()
+
+    def test_valid_create(self):
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "anderePartijIdentificator": "anderePartijIdentificator",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PartijIdentificator.objects.all().count(), 1)
+
+    def test_valid_create_with_sub_identificator_van(self):
+        partij_identificator = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "sub_identificator_van": {"uuid": str(partij_identificator.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)
+
+    def test_invalid_create_partij_required(self):
+        data = {
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "identificeerdePartij")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+
+    def test_invalid_create_duplicate_code_soort_object_id_for_partij(self):
+        BsnPartijIdentificatorFactory.create(partij=self.partij)
+
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "123456782",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "__all__")
+        self.assertEqual(error["code"], "unique_together")
+        self.assertEqual(
+            error["reason"],
+            "Partij identificator met deze Partij en Soort object ID bestaat al.",
+        )
+
+    def test_valid_update_partij(self):
+        partij_identificator = BsnPartijIdentificatorFactory.create(
+            partij=PartijFactory.create()
+        )
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+        # check if this partij_identificator can be assigned to self.partij
+        self.assertEqual(self.partij.partijidentificator_set.count(), 0)
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(self.partij.uuid))
+
+    def test_invalid_update_partij(self):
+        new_partij = PartijFactory.create()
+        BsnPartijIdentificatorFactory.create(
+            partij=new_partij,
+            partij_identificator_object_id="123456782",
+        )
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=self.partij)
+        data = {
+            "identificeerdePartij": {"uuid": str(new_partij.uuid)},
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        # check if this partij_identificator can be assigned to self.partij
+        self.assertEqual(new_partij.partijidentificator_set.count(), 1)
+        self.assertEqual(
+            new_partij.partijidentificator_set.filter(
+                partij_identificator_code_soort_object_id="bsn"
+            ).count(),
+            1,
+        )
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "__all__")
+        self.assertEqual(error["code"], "unique_together")
+        self.assertEqual(
+            error["reason"],
+            "Partij identificator met deze Partij en Soort object ID bestaat al.",
+        )
+        self.assertEqual(new_partij.partijidentificator_set.count(), 1)
+        self.assertEqual(
+            new_partij.partijidentificator_set.filter(
+                partij_identificator_code_soort_object_id="bsn"
+            ).count(),
+            1,
+        )
+
+    def test_valid_update_check_uniqueness_values(self):
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=self.partij)
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "anderePartijIdentificator": "changed",
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "123456782",
+                "codeRegister": "brp",
+            },
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(self.partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "changed")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "123456782",
+                "codeRegister": "brp",
+            },
+        )
+
+    def test_invalid_update_check_uniqueness_exists(self):
+        partij_identificator_a = BsnPartijIdentificatorFactory.create(
+            partij=self.partij,
+            partij_identificator_object_id="123456782",
+        )
+        partij_identificator_b = BsnPartijIdentificatorFactory.create(
+            partij=PartijFactory.create(),
+        )
+        # update partij_identificator_a with partij_identificator_b data
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator_a.uuid)},
+        )
+
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "anderePartijIdentificator": "changed",
+            "partijIdentificator": {
+                "codeObjecttype": partij_identificator_b.partij_identificator_code_objecttype,
+                "codeSoortObjectId": partij_identificator_b.partij_identificator_code_soort_object_id,
+                "objectId": partij_identificator_b.partij_identificator_object_id,
+                "codeRegister": partij_identificator_b.partij_identificator_code_register,
+            },
+        }
+        # partij_identificator already exists
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "__all__")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            "`PartijIdentificator` moet uniek zijn, er bestaat er al een met deze gegevenscombinatie.",
+        )
+
+    def test_valid_check_uniqueness_sub_identificator_van(self):
+        BsnPartijIdentificatorFactory.create(partij=self.partij)
+        # Same values, but sub_identifier_van is set
+        partij = PartijFactory.create()
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=partij
+        )
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)
+        data = {
+            "identificeerdePartij": {"uuid": str(partij.uuid)},
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PartijIdentificator.objects.all().count(), 3)
+
+    def test_invalid_check_uniqueness_sub_identificator_van(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        BsnPartijIdentificatorFactory.create(
+            partij=self.partij, sub_identificator_van=sub_identificator_van
+        )
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)
+        # Same values and same sub_identificator_van
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "__all__")
+        self.assertEqual(error["code"], "unique_together")
+        self.assertEqual(
+            error["reason"],
+            "Partij identificator met deze Partij en Soort object ID bestaat al.",
+        )
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)
+
+    def test_vestigingsnummer_valid_create(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        partij_identificatoren = PartijIdentificator.objects.all()
+        self.assertEqual(partij_identificatoren.count(), 2)
+
+    def test_vestigingsnummer_invalid_create_without_sub_identificator_van(self):
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "subIdentificatorVan")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            (
+                "Voor een PartijIdentificator met codeSoortObjectId = `vestigingsnummer` "
+                "is het verplicht om een `sub_identifier_van` met codeSoortObjectId = "
+                "`kvk_nummer` te kiezen."
+            ),
+        )
+
+    def test_vestigingsnummer_invalid_create_without_partij(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+
+        data = {
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "identificeerdePartij")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+
+    def test_vestigingsnummer_valid_create_external_partij(self):
+        partij = PartijFactory.create()
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=partij
+        )
+
+        # sub_identificator_van partij is different from vestigingsnummer partij
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)
+
+    def test_vestigingsnummer_invalid_create_invalid_sub_identificator_van(self):
+        sub_identificator_van = BsnPartijIdentificatorFactory.create(partij=self.partij)
+
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "subIdentificatorVan")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            "Het is alleen mogelijk om een subIdentifierVan te selecteren met codeSoortObjectId = `kvk_nummer`.",
+        )
+
+    def test_vestigingsnummer_valid_update(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        partij_identificator = VestigingsnummerPartijIdentificatorFactory.create(
+            partij=self.partij,
+            sub_identificator_van=sub_identificator_van,
+        )
+
+        self.assertEqual(PartijIdentificator.objects.count(), 2)
+
+        data = {
+            "anderePartijIdentificator": "changed",
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["identificeerdePartij"]["uuid"], str(self.partij.uuid))
+        self.assertEqual(data["anderePartijIdentificator"], "changed")
+        self.assertEqual(
+            data["partijIdentificator"],
+            {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        )
+
+    def test_vestigingsnummer_invalid_update_set_sub_identificator_van_null(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        partij_identificator = VestigingsnummerPartijIdentificatorFactory.create(
+            partij=self.partij, sub_identificator_van=sub_identificator_van
+        )
+
+        self.assertEqual(PartijIdentificator.objects.count(), 2)
+
+        data = {
+            "sub_identificator_van": None,
+        }
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "subIdentificatorVan")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            (
+                "Voor een PartijIdentificator met codeSoortObjectId = `vestigingsnummer` is het verplicht om"
+                " een `sub_identifier_van` met codeSoortObjectId = `kvk_nummer` te kiezen."
+            ),
+        )
+
+    def test_invalid_vestigingsnummer_and_kvk_nummer_combination_unique(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        VestigingsnummerPartijIdentificatorFactory.create(
+            partij=self.partij,
+            sub_identificator_van=sub_identificator_van,
+        )
+        # Same sub_identificator_van and same data_values
+        data = {
+            "identificeerdePartij": {"uuid": str(self.partij.uuid)},
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response.data["invalid_params"]), 2)
+        self.assertEqual(response.data["invalid_params"][0]["code"], "unique_together")
+        self.assertEqual(
+            response.data["invalid_params"][0]["reason"],
+            "Partij identificator met deze Partij en Soort object ID bestaat al.",
+        )
+        self.assertEqual(response.data["invalid_params"][1]["code"], "invalid")
+        self.assertEqual(
+            response.data["invalid_params"][1]["reason"],
+            "`PartijIdentificator` moet uniek zijn, er bestaat er al een met deze gegevenscombinatie.",
+        )
+
+    def test_valid_protect_delete(self):
+        partij_identificator = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(partij_identificator.uuid)},
+        )
+        self.assertEqual(PartijIdentificator.objects.all().count(), 1)
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(PartijIdentificator.objects.all().count(), 0)
+
+    def test_invalid_protect_delete(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij
+        )
+        VestigingsnummerPartijIdentificatorFactory.create(
+            partij=self.partij,
+            sub_identificator_van=sub_identificator_van,
+        )
+        detail_url = reverse(
+            "klantinteracties:partijidentificator-detail",
+            kwargs={"uuid": str(sub_identificator_van.uuid)},
+        )
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "nonFieldErrors")
+        self.assertEqual(error["code"], "invalid")
+        self.assertEqual(
+            error["reason"],
+            (
+                "Cannot delete some instances of model 'PartijIdentificator' because they are"
+                " referenced through protected foreign keys: 'PartijIdentificator.sub_identificator_van'."
+            ),
+        )
+
+        self.assertEqual(PartijIdentificator.objects.all().count(), 2)

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_vertegenwoordigden.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_vertegenwoordigden.py
@@ -1,0 +1,178 @@
+from rest_framework import status
+from vng_api_common.tests import get_validation_errors, reverse
+
+from openklant.components.klantinteracties.models.tests.factories.partijen import (
+    PartijFactory,
+    VertegenwoordigdenFactory,
+)
+from openklant.components.token.tests.api_testcase import APITestCase
+
+
+class VertegenwoordigdenTests(APITestCase):
+    def test_list_vertegenwoordigden(self):
+        list_url = reverse("klantinteracties:vertegenwoordigden-list")
+        VertegenwoordigdenFactory.create_batch(2)
+
+        response = self.client.get(list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_read_vertegenwoordigden(self):
+        vertegenwoordigden = VertegenwoordigdenFactory.create()
+        detail_url = reverse(
+            "klantinteracties:vertegenwoordigden-detail",
+            kwargs={"uuid": str(vertegenwoordigden.uuid)},
+        )
+
+        response = self.client.get(detail_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["url"], "http://testserver" + detail_url)
+
+    def test_create_vertegenwoordigden(self):
+        list_url = reverse("klantinteracties:vertegenwoordigden-list")
+        partij, partij2 = PartijFactory.create_batch(2)
+        data = {
+            "vertegenwoordigendePartij": {"uuid": str(partij.uuid)},
+            "vertegenwoordigdePartij": {"uuid": str(partij2.uuid)},
+        }
+
+        response = self.client.post(list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["vertegenwoordigendePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["vertegenwoordigdePartij"]["uuid"], str(partij2.uuid))
+
+        with self.subTest("test_unique_together"):
+            response = self.client.post(list_url, data)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            error = get_validation_errors(response, "nonFieldErrors")
+            self.assertEqual(error["code"], "unique")
+            self.assertEqual(
+                error["reason"],
+                "De velden vertegenwoordigende_partij, vertegenwoordigde_partij moeten een unieke set zijn.",
+            )
+
+        with self.subTest("test_partij_can_not_vertegenwoordig_it_self"):
+            data = {
+                "vertegenwoordigendePartij": {"uuid": str(partij.uuid)},
+                "vertegenwoordigdePartij": {"uuid": str(partij.uuid)},
+            }
+            response = self.client.post(list_url, data)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            error = get_validation_errors(response, "vertegenwoordigdePartij")
+            self.assertEqual(error["code"], "invalid")
+            self.assertEqual(
+                error["reason"],
+                "De partij kan niet zichzelf vertegenwoordigen.",
+            )
+
+    def test_update_vertegenwoordigden(self):
+        partij, partij2, partij3, partij4 = PartijFactory.create_batch(4)
+        vertegenwoordigden = VertegenwoordigdenFactory.create(
+            vertegenwoordigende_partij=partij,
+            vertegenwoordigde_partij=partij2,
+        )
+        detail_url = reverse(
+            "klantinteracties:vertegenwoordigden-detail",
+            kwargs={"uuid": str(vertegenwoordigden.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["vertegenwoordigendePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["vertegenwoordigdePartij"]["uuid"], str(partij2.uuid))
+
+        data = {
+            "vertegenwoordigendePartij": {"uuid": str(partij3.uuid)},
+            "vertegenwoordigdePartij": {"uuid": str(partij4.uuid)},
+        }
+
+        response = self.client.put(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["vertegenwoordigendePartij"]["uuid"], str(partij3.uuid))
+        self.assertEqual(data["vertegenwoordigdePartij"]["uuid"], str(partij4.uuid))
+
+    def test_update_partial_vertegenwoordigden(self):
+        partij, partij2, partij3 = PartijFactory.create_batch(3)
+        vertegenwoordigden = VertegenwoordigdenFactory.create(
+            vertegenwoordigende_partij=partij,
+            vertegenwoordigde_partij=partij2,
+        )
+        detail_url = reverse(
+            "klantinteracties:vertegenwoordigden-detail",
+            kwargs={"uuid": str(vertegenwoordigden.uuid)},
+        )
+        response = self.client.get(detail_url)
+        data = response.json()
+
+        self.assertEqual(data["vertegenwoordigendePartij"]["uuid"], str(partij.uuid))
+        self.assertEqual(data["vertegenwoordigdePartij"]["uuid"], str(partij2.uuid))
+
+        data = {
+            "vertegenwoordigendePartij": {"uuid": str(partij3.uuid)},
+        }
+
+        response = self.client.patch(detail_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["vertegenwoordigendePartij"]["uuid"], str(partij3.uuid))
+        self.assertEqual(data["vertegenwoordigdePartij"]["uuid"], str(partij2.uuid))
+
+        with self.subTest("test_partij_can_not_vertegenwoordig_it_self"):
+            data = {
+                "vertegenwoordigendePartij": {"uuid": str(partij2.uuid)},
+            }
+            response = self.client.patch(detail_url, data)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            error = get_validation_errors(response, "vertegenwoordigdePartij")
+            self.assertEqual(error["code"], "invalid")
+            self.assertEqual(
+                error["reason"],
+                "De partij kan niet zichzelf vertegenwoordigen.",
+            )
+
+        with self.subTest("test_unique_together"):
+            vertegenwoordigden = VertegenwoordigdenFactory.create(
+                vertegenwoordigende_partij=partij,
+                vertegenwoordigde_partij=partij2,
+            )
+            detail_url = reverse(
+                "klantinteracties:vertegenwoordigden-detail",
+                kwargs={"uuid": str(vertegenwoordigden.uuid)},
+            )
+            data = {
+                "vertegenwoordigendePartij": {"uuid": str(partij3.uuid)},
+            }
+
+            # update new vertegenwoordigde object to have same data as the existing one.
+            response = self.client.patch(detail_url, data)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            error = get_validation_errors(response, "nonFieldErrors")
+            self.assertEqual(error["code"], "unique")
+            self.assertEqual(
+                error["reason"],
+                "De velden vertegenwoordigende_partij, vertegenwoordigde_partij moeten een unieke set zijn.",
+            )
+
+    def test_destroy_vertegenwoordigden(self):
+        vertegenwoordigden = VertegenwoordigdenFactory.create()
+        detail_url = reverse(
+            "klantinteracties:vertegenwoordigden-detail",
+            kwargs={"uuid": str(vertegenwoordigden.uuid)},
+        )
+        response = self.client.delete(detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        list_url = reverse("klantinteracties:vertegenwoordigden-list")
+        response = self.client.get(list_url)
+        data = response.json()
+        self.assertEqual(data["count"], 0)

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -2280,10 +2280,7 @@ class NestedPartijIdentificatorTests(APITestCase):
 
     def test_read(self):
         partij = PartijFactory.create()
-        partij_identificator = BsnPartijIdentificatorFactory.create(
-            partij=partij,
-            partij_identificator_object_id="296648875",
-        )
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=partij)
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -2478,9 +2475,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             "soortPartij": "persoon",
             "indicatieActief": True,
         }
-        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="12345678"
-        )
+        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(partij=partij)
         # pass kvk_nummer uuid for new bsn data
         data["partijIdentificatoren"][0]["uuid"] = str(kvk_nummer.uuid)
         response = self.client.post(self.list_url, data)
@@ -2541,9 +2536,7 @@ class NestedPartijIdentificatorTests(APITestCase):
 
         # pass kvk_nummer uuid for new bsn data
         new_partij = PartijFactory.create()
-        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(
-            partij=new_partij, partij_identificator_object_id="11112222"
-        )
+        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(partij=new_partij)
         data["partijIdentificatoren"][0]["uuid"] = str(kvk_nummer.uuid)
         response = self.client.post(self.list_url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -2655,9 +2648,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             self.assertEqual(response_data["soortPartij"], "organisatie")
             self.assertEqual(partij.partijidentificator_set.count(), 0)
 
-            BsnPartijIdentificatorFactory.create(
-                partij=partij, partij_identificator_object_id="296648875"
-            )
+            BsnPartijIdentificatorFactory.create(partij=partij)
             # Resend update request
             # No changes to the partij_identificator because the value wasn't specified in PATCH
             self.assertEqual(partij.partijidentificator_set.count(), 1)
@@ -2723,14 +2714,10 @@ class NestedPartijIdentificatorTests(APITestCase):
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
-        bsn = BsnPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="296648875"
-        )
-        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="12345678"
-        )
+        bsn = BsnPartijIdentificatorFactory.create(partij=partij)
+        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(partij=partij)
         vestigingsnummer = VestigingsnummerPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="111122223333"
+            partij=partij
         )
 
         # changes are only for objectId
@@ -2809,12 +2796,8 @@ class NestedPartijIdentificatorTests(APITestCase):
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
-        bsn = BsnPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="296648875"
-        )
-        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="12345678"
-        )
+        bsn = BsnPartijIdentificatorFactory.create(partij=partij)
+        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(partij=partij)
 
         # changes are only for objectId
         data = {
@@ -2874,14 +2857,10 @@ class NestedPartijIdentificatorTests(APITestCase):
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
-        bsn = BsnPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="296648875"
-        )
-        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="12345678"
-        )
+        bsn = BsnPartijIdentificatorFactory.create(partij=partij)
+        kvk_nummer = KvkNummerPartijIdentificatorFactory.create(partij=partij)
         vestigingsnummer = VestigingsnummerPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="111122223333"
+            partij=partij
         )
 
         # changes are only for objectId
@@ -2960,9 +2939,7 @@ class NestedPartijIdentificatorTests(APITestCase):
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
-        bsn = BsnPartijIdentificatorFactory.create(
-            partij=partij, partij_identificator_object_id="296648875"
-        )
+        bsn = BsnPartijIdentificatorFactory.create(partij=partij)
 
         self.assertTrue(partij.partijidentificator_set.count(), 1)
         self.assertFalse(
@@ -3116,13 +3093,7 @@ class PartijIdentificatorTests(APITestCase):
     def test_list(self):
         list_url = reverse("klantinteracties:partijidentificator-list")
         partij = PartijFactory.create()
-        PartijIdentificator.objects.create(
-            partij=partij,
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
-            partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
-        )
+        BsnPartijIdentificatorFactory.create(partij=partij)
         PartijIdentificator.objects.create(
             partij=partij,
             partij_identificator_code_objecttype="niet_natuurlijk_persoon",
@@ -3185,7 +3156,6 @@ class PartijIdentificatorTests(APITestCase):
         partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="296648875",
         )
 
         detail_url = reverse(
@@ -3239,7 +3209,6 @@ class PartijIdentificatorTests(APITestCase):
         partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="296648875",
         )
 
         detail_url = reverse(
@@ -3287,7 +3256,6 @@ class PartijIdentificatorTests(APITestCase):
         partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="123456782",
         )
 
         data = {
@@ -3310,7 +3278,7 @@ class PartijIdentificatorTests(APITestCase):
             "partijIdentificator": {
                 "codeObjecttype": "natuurlijk_persoon",
                 "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
+                "objectId": "123456782",
                 "codeRegister": "brp",
             },
         }
@@ -3326,7 +3294,7 @@ class PartijIdentificatorTests(APITestCase):
             {
                 "codeObjecttype": "natuurlijk_persoon",
                 "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
+                "objectId": "123456782",
                 "codeRegister": "brp",
             },
         )
@@ -3484,11 +3452,7 @@ class PartijIdentificatorTests(APITestCase):
     def test_invalid_update_partial_partij_identificator(self):
         # all partij_identificator values are required
         partij = PartijFactory.create()
-        partij_identificator = BsnPartijIdentificatorFactory.create(
-            partij=partij,
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="123456782",
-        )
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=partij)
         data = {
             "identificeerdePartij": None,
             "partijIdentificator": {},
@@ -3551,9 +3515,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_valid_create_with_sub_identificator_van(self):
         partij_identificator = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
@@ -3585,17 +3547,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(error["reason"], "Dit veld is vereist.")
 
     def test_invalid_create_duplicate_code_soort_object_id_for_partij(self):
-        BsnPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="123456782",
-        )
+        BsnPartijIdentificatorFactory.create(partij=self.partij)
 
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
             "partijIdentificator": {
                 "codeObjecttype": "natuurlijk_persoon",
                 "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
+                "objectId": "123456782",
                 "codeRegister": "brp",
             },
         }
@@ -3610,9 +3569,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_valid_update_partij(self):
         partij_identificator = BsnPartijIdentificatorFactory.create(
-            partij=PartijFactory.create(),
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="123456782",
+            partij=PartijFactory.create()
         )
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
@@ -3633,14 +3590,9 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         new_partij = PartijFactory.create()
         BsnPartijIdentificatorFactory.create(
             partij=new_partij,
-            andere_partij_identificator="anderePartijIdentificator",
             partij_identificator_object_id="123456782",
         )
-        partij_identificator = BsnPartijIdentificatorFactory.create(
-            partij=self.partij,
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="296648875",
-        )
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=self.partij)
         data = {
             "identificeerdePartij": {"uuid": str(new_partij.uuid)},
         }
@@ -3676,18 +3628,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_valid_update_check_uniqueness_values(self):
-        partij_identificator = BsnPartijIdentificatorFactory.create(
-            partij=self.partij,
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_object_id="123456782",
-        )
+        partij_identificator = BsnPartijIdentificatorFactory.create(partij=self.partij)
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
             "anderePartijIdentificator": "changed",
             "partijIdentificator": {
                 "codeObjecttype": "natuurlijk_persoon",
                 "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
+                "objectId": "123456782",
                 "codeRegister": "brp",
             },
         }
@@ -3706,7 +3654,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
             {
                 "codeObjecttype": "natuurlijk_persoon",
                 "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
+                "objectId": "123456782",
                 "codeRegister": "brp",
             },
         )
@@ -3718,7 +3666,6 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
         partij_identificator_b = BsnPartijIdentificatorFactory.create(
             partij=PartijFactory.create(),
-            partij_identificator_object_id="296648875",
         )
         # update partij_identificator_a with partij_identificator_b data
         detail_url = reverse(
@@ -3747,15 +3694,11 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_valid_check_uniqueness_sub_identificator_van(self):
-        BsnPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="296648875",
-        )
+        BsnPartijIdentificatorFactory.create(partij=self.partij)
         # Same values, but sub_identifier_van is set
         partij = PartijFactory.create()
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=partij,
-            partij_identificator_object_id="12345678",
+            partij=partij
         )
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         data = {
@@ -3774,13 +3717,10 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_invalid_check_uniqueness_sub_identificator_van(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         BsnPartijIdentificatorFactory.create(
-            partij=self.partij,
-            sub_identificator_van=sub_identificator_van,
-            partij_identificator_object_id="296648875",
+            partij=self.partij, sub_identificator_van=sub_identificator_van
         )
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         # Same values and same sub_identificator_van
@@ -3806,8 +3746,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_vestigingsnummer_valid_create(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
 
         data = {
@@ -3852,8 +3791,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_vestigingsnummer_invalid_create_without_partij(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
 
         data = {
@@ -3875,8 +3813,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
     def test_vestigingsnummer_valid_create_external_partij(self):
         partij = PartijFactory.create()
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=partij,
-            partij_identificator_object_id="12345678",
+            partij=partij
         )
 
         # sub_identificator_van partij is different from vestigingsnummer partij
@@ -3895,10 +3832,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
     def test_vestigingsnummer_invalid_create_invalid_sub_identificator_van(self):
-        sub_identificator_van = BsnPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="296648875",
-        )
+        sub_identificator_van = BsnPartijIdentificatorFactory.create(partij=self.partij)
 
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
@@ -3922,13 +3856,11 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_vestigingsnummer_valid_update(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         partij_identificator = VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_object_id="111122223333",
         )
 
         self.assertEqual(PartijIdentificator.objects.count(), 2)
@@ -3951,20 +3883,17 @@ class PartijIdentificatorUniquenessTests(APITestCase):
             {
                 "codeObjecttype": "vestiging",
                 "codeSoortObjectId": "vestigingsnummer",
-                "objectId": "111122223333",
+                "objectId": "296648875154",
                 "codeRegister": "hr",
             },
         )
 
     def test_vestigingsnummer_invalid_update_set_sub_identificator_van_null(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         partij_identificator = VestigingsnummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            sub_identificator_van=sub_identificator_van,
-            partij_identificator_object_id="111122223333",
+            partij=self.partij, sub_identificator_van=sub_identificator_van
         )
 
         self.assertEqual(PartijIdentificator.objects.count(), 2)
@@ -3991,13 +3920,11 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_invalid_vestigingsnummer_and_kvk_nummer_combination_unique(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_object_id="296648875154",
         )
         # Same sub_identificator_van and same data_values
         data = {
@@ -4027,8 +3954,7 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_valid_protect_delete(self):
         partij_identificator = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         detail_url = reverse(
             "klantinteracties:partijidentificator-detail",
@@ -4041,13 +3967,11 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_invalid_protect_delete(self):
         sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
-            partij=self.partij,
-            partij_identificator_object_id="12345678",
+            partij=self.partij
         )
         VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_object_id="296648875154",
         )
         detail_url = reverse(
             "klantinteracties:partijidentificator-detail",

--- a/src/openklant/components/klantinteracties/api/tests/test_partijen.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_partijen.py
@@ -10,17 +10,21 @@ from openklant.components.klantinteracties.models.partijen import (
     Partij,
     PartijIdentificator,
 )
-from openklant.components.klantinteracties.models.tests.factories import (
+from openklant.components.klantinteracties.models.tests.factories.digitaal_adres import (
+    DigitaalAdresFactory,
+)
+from openklant.components.klantinteracties.models.tests.factories.partijen import (
     CategorieFactory,
     CategorieRelatieFactory,
     ContactpersoonFactory,
-    DigitaalAdresFactory,
     OrganisatieFactory,
     PartijFactory,
     PartijIdentificatorFactory,
     PersoonFactory,
-    RekeningnummerFactory,
     VertegenwoordigdenFactory,
+)
+from openklant.components.klantinteracties.models.tests.factories.rekeningnummer import (
+    RekeningnummerFactory,
 )
 from openklant.components.token.tests.api_testcase import APITestCase
 
@@ -2144,12 +2148,9 @@ class PartijTests(APITestCase):
 
     def test_get_partij_and_partij_identificatoren(self):
         partij = PartijFactory.create()
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
@@ -2411,81 +2412,11 @@ class PartijIdentificatorTests(APITestCase):
             },
         )
 
-    def test_create_partij_identificator_without_partij(self):
-        with self.subTest("with identificeerdePartij not explicitly specified"):
-            list_url = reverse("klantinteracties:partijidentificator-list")
-            data = {
-                "anderePartijIdentificator": "anderePartijIdentificator",
-                "partijIdentificator": {
-                    "codeObjecttype": "natuurlijk_persoon",
-                    "codeSoortObjectId": "bsn",
-                    "objectId": "296648875",
-                    "codeRegister": "brp",
-                },
-            }
-
-            response = self.client.post(list_url, data)
-            self.assertEqual(
-                response.status_code, status.HTTP_201_CREATED, response.data
-            )
-            data = response.json()
-
-            self.assertEqual(data["identificeerdePartij"], None)
-            self.assertEqual(
-                data["anderePartijIdentificator"], "anderePartijIdentificator"
-            )
-            self.assertEqual(
-                data["partijIdentificator"],
-                {
-                    "codeObjecttype": "natuurlijk_persoon",
-                    "codeSoortObjectId": "bsn",
-                    "objectId": "296648875",
-                    "codeRegister": "brp",
-                },
-            )
-
-        with self.subTest("with identificeerdePartij explicitly set to null"):
-            list_url = reverse("klantinteracties:partijidentificator-list")
-            data = {
-                "identificeerdePartij": None,
-                "anderePartijIdentificator": "anderePartijIdentificator",
-                "partijIdentificator": {
-                    "codeObjecttype": "natuurlijk_persoon",
-                    "codeSoortObjectId": "bsn",
-                    "objectId": "111222333",
-                    "codeRegister": "brp",
-                },
-            }
-
-            response = self.client.post(list_url, data)
-            self.assertEqual(
-                response.status_code, status.HTTP_201_CREATED, response.data
-            )
-            data = response.json()
-
-            self.assertEqual(data["identificeerdePartij"], None)
-            self.assertEqual(
-                data["anderePartijIdentificator"], "anderePartijIdentificator"
-            )
-            self.assertEqual(
-                data["partijIdentificator"],
-                {
-                    "codeObjecttype": "natuurlijk_persoon",
-                    "codeSoortObjectId": "bsn",
-                    "objectId": "111222333",
-                    "codeRegister": "brp",
-                },
-            )
-
     def test_update_partij_identificator(self):
         partij, partij2 = PartijFactory.create_batch(2)
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
 
         detail_url = reverse(
@@ -2534,58 +2465,12 @@ class PartijIdentificatorTests(APITestCase):
             },
         )
 
-    def test_update_partij_identificator_with_partij_null(self):
-        partij = PartijFactory.create()
-        partij_identificator = PartijIdentificatorFactory.create(
-            partij=partij,
-            andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
-            partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
-        )
-
-        detail_url = reverse(
-            "klantinteracties:partijidentificator-detail",
-            kwargs={"uuid": str(partij_identificator.uuid)},
-        )
-
-        data = {
-            "identificeerdePartij": None,
-            "anderePartijIdentificator": "changed",
-            "partijIdentificator": {
-                "codeObjecttype": "natuurlijk_persoon",
-                "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
-                "codeRegister": "brp",
-            },
-        }
-
-        response = self.client.put(detail_url, data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-
-        self.assertEqual(data["identificeerdePartij"], None)
-        self.assertEqual(data["anderePartijIdentificator"], "changed")
-        self.assertEqual(
-            data["partijIdentificator"],
-            {
-                "codeObjecttype": "natuurlijk_persoon",
-                "codeSoortObjectId": "bsn",
-                "objectId": "296648875",
-                "codeRegister": "brp",
-            },
-        )
-
     def test_partial_update_partij_identificator(self):
         partij = PartijFactory.create()
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
 
         detail_url = reverse(
@@ -2781,13 +2666,10 @@ class PartijIdentificatorTests(APITestCase):
         # all partij_identificator fields required
         partij = PartijFactory.create()
         list_url = reverse("klantinteracties:partijidentificator-list")
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="123456782",
-            partij_identificator_code_register="brp",
         )
 
         data = {
@@ -2837,13 +2719,10 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 1)
 
     def test_valid_create_with_sub_identificator_van(self):
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
@@ -2859,10 +2738,25 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
+    def test_invalid_create_partij_required(self):
+        data = {
+            "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "296648875",
+                "codeRegister": "brp",
+            },
+        }
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "identificeerdePartij")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+
     def test_invalid_create_duplicate_code_soort_object_id_for_partij(self):
-        PartijIdentificatorFactory.create(
+        BsnPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_soort_object_id="bsn",
+            partij_identificator_object_id="296648875",
         )
 
         data = {
@@ -2884,13 +2778,10 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_valid_update_partij(self):
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=PartijFactory.create(),
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="123456782",
-            partij_identificator_code_register="brp",
         )
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
@@ -2909,22 +2800,15 @@ class PartijIdentificatorUniquenessTests(APITestCase):
 
     def test_invalid_update_partij(self):
         new_partij = PartijFactory.create()
-        PartijIdentificatorFactory.create(
+        BsnPartijIdentificatorFactory.create(
             partij=new_partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="123456782",
-            partij_identificator_code_register="brp",
         )
-
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=self.partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
         data = {
             "identificeerdePartij": {"uuid": str(new_partij.uuid)},
@@ -2961,15 +2845,11 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_valid_update_check_uniqueness_values(self):
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = BsnPartijIdentificatorFactory.create(
             partij=self.partij,
             andere_partij_identificator="anderePartijIdentificator",
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="123456782",
-            partij_identificator_code_register="brp",
         )
-
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
             "anderePartijIdentificator": "changed",
@@ -3001,20 +2881,13 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_invalid_update_check_uniqueness_exists(self):
-        partij_identificator_a = PartijIdentificatorFactory.create(
+        partij_identificator_a = BsnPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="123456782",
-            partij_identificator_code_register="brp",
         )
-
-        partij_identificator_b = PartijIdentificatorFactory.create(
+        partij_identificator_b = BsnPartijIdentificatorFactory.create(
             partij=PartijFactory.create(),
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
         # update partij_identificator_a with partij_identificator_b data
         detail_url = reverse(
@@ -3043,21 +2916,15 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_valid_check_uniqueness_sub_identificator_van(self):
-        PartijIdentificatorFactory.create(
+        BsnPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
         # Same values, but sub_identifier_van is set
         partij = PartijFactory.create()
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         data = {
@@ -3075,20 +2942,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 3)
 
     def test_invalid_check_uniqueness_sub_identificator_van(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
-        PartijIdentificatorFactory.create(
+        BsnPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         # Same values and same sub_identificator_van
@@ -3113,12 +2974,9 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
     def test_vestigingsnummer_valid_create(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
 
         data = {
@@ -3161,14 +3019,33 @@ class PartijIdentificatorUniquenessTests(APITestCase):
             ),
         )
 
+    def test_vestigingsnummer_invalid_create_without_partij(self):
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
+            partij=self.partij,
+            partij_identificator_object_id="12345678",
+        )
+
+        data = {
+            "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
+            "partijIdentificator": {
+                "codeObjecttype": "vestiging",
+                "codeSoortObjectId": "vestigingsnummer",
+                "objectId": "296648875154",
+                "codeRegister": "hr",
+            },
+        }
+
+        response = self.client.post(self.list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, "identificeerdePartij")
+        self.assertEqual(error["code"], "required")
+        self.assertEqual(error["reason"], "Dit veld is vereist.")
+
     def test_vestigingsnummer_valid_create_external_partij(self):
         partij = PartijFactory.create()
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
 
         # sub_identificator_van partij is different from vestigingsnummer partij
@@ -3187,13 +3064,11 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
     def test_vestigingsnummer_invalid_create_invalid_sub_identificator_van(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = BsnPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="bsn",
             partij_identificator_object_id="296648875",
-            partij_identificator_code_register="brp",
         )
+
         data = {
             "identificeerdePartij": {"uuid": str(self.partij.uuid)},
             "sub_identificator_van": {"uuid": str(sub_identificator_van.uuid)},
@@ -3215,20 +3090,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_vestigingsnummer_valid_update(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_code_objecttype="vestiging",
-            partij_identificator_code_soort_object_id="vestigingsnummer",
             partij_identificator_object_id="111122223333",
-            partij_identificator_code_register="hr",
         )
 
         self.assertEqual(PartijIdentificator.objects.count(), 2)
@@ -3257,20 +3126,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_vestigingsnummer_invalid_update_set_sub_identificator_van_null(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_code_objecttype="vestiging",
-            partij_identificator_code_soort_object_id="vestigingsnummer",
             partij_identificator_object_id="111122223333",
-            partij_identificator_code_register="hr",
         )
 
         self.assertEqual(PartijIdentificator.objects.count(), 2)
@@ -3296,20 +3159,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_invalid_vestigingsnummer_and_kvk_nummer_combination_unique(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
-        PartijIdentificatorFactory.create(
+        VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_code_objecttype="vestiging",
-            partij_identificator_code_soort_object_id="vestigingsnummer",
             partij_identificator_object_id="296648875154",
-            partij_identificator_code_register="hr",
         )
         # Same sub_identificator_van and same data_values
         data = {
@@ -3338,12 +3195,9 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         )
 
     def test_valid_protect_delete(self):
-        partij_identificator = PartijIdentificatorFactory.create(
+        partij_identificator = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
         detail_url = reverse(
             "klantinteracties:partijidentificator-detail",
@@ -3355,20 +3209,14 @@ class PartijIdentificatorUniquenessTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 0)
 
     def test_invalid_protect_delete(self):
-        sub_identificator_van = PartijIdentificatorFactory.create(
+        sub_identificator_van = KvkNummerPartijIdentificatorFactory.create(
             partij=self.partij,
-            partij_identificator_code_objecttype="niet_natuurlijk_persoon",
-            partij_identificator_code_soort_object_id="kvk_nummer",
             partij_identificator_object_id="12345678",
-            partij_identificator_code_register="hr",
         )
-        PartijIdentificatorFactory.create(
+        VestigingsnummerPartijIdentificatorFactory.create(
             partij=self.partij,
             sub_identificator_van=sub_identificator_van,
-            partij_identificator_code_objecttype="vestiging",
-            partij_identificator_code_soort_object_id="vestigingsnummer",
             partij_identificator_object_id="296648875154",
-            partij_identificator_code_register="hr",
         )
         detail_url = reverse(
             "klantinteracties:partijidentificator-detail",

--- a/src/openklant/components/klantinteracties/api/viewsets/partijen.py
+++ b/src/openklant/components/klantinteracties/api/viewsets/partijen.py
@@ -75,6 +75,7 @@ class PartijViewSet(NotificationViewSetMixin, ExpandMixin, viewsets.ModelViewSet
         .prefetch_related(
             "betrokkene_set",
             "digitaaladres_set",
+            "partijidentificator_set",
         )
     )
     serializer_class = PartijSerializer

--- a/src/openklant/components/klantinteracties/api/viewsets/partijen.py
+++ b/src/openklant/components/klantinteracties/api/viewsets/partijen.py
@@ -10,6 +10,10 @@ from openklant.components.klantinteracties.api.filterset.partijen import (
     PartijFilterSet,
     VertegenwoordigdenFilterSet,
 )
+from openklant.components.klantinteracties.api.schema import (
+    PARTIJ_IDENTIFICATOR_DESCRIPTION_CREATE,
+    PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE,
+)
 from openklant.components.klantinteracties.api.serializers.partijen import (
     CategorieRelatieSerializer,
     CategorieSerializer,
@@ -43,15 +47,15 @@ from openklant.utils.decorators import handle_db_exceptions
     ),
     create=extend_schema(
         summary="Maak een partij aan.",
-        description="Maak een partij aan.",
+        description=PARTIJ_IDENTIFICATOR_DESCRIPTION_CREATE,
     ),
     update=extend_schema(
         summary="Werk een partij in zijn geheel bij.",
-        description="Werk een partij in zijn geheel bij.",
+        description=PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE,
     ),
     partial_update=extend_schema(
         summary="Werk een partij deels bij.",
-        description="Werk een partij deels bij.",
+        description=PARTIJ_IDENTIFICATOR_DESCRIPTION_UPDATE,
     ),
     destroy=extend_schema(
         summary="Verwijder een partij.",

--- a/src/openklant/components/klantinteracties/models/tests/factories/partijen.py
+++ b/src/openklant/components/klantinteracties/models/tests/factories/partijen.py
@@ -103,6 +103,7 @@ class BsnPartijIdentificatorFactory(PartijIdentificatorFactory):
         PartijIdentificatorCodeSoortObjectId.bsn.value
     )
     partij_identificator_code_register = PartijIdentificatorCodeRegister.brp.value
+    partij_identificator_object_id = "296648875"
 
 
 class KvkNummerPartijIdentificatorFactory(PartijIdentificatorFactory):
@@ -113,6 +114,7 @@ class KvkNummerPartijIdentificatorFactory(PartijIdentificatorFactory):
         PartijIdentificatorCodeSoortObjectId.kvk_nummer.value
     )
     partij_identificator_code_register = PartijIdentificatorCodeRegister.hr.value
+    partij_identificator_object_id = "12345678"
 
 
 class VestigingsnummerPartijIdentificatorFactory(PartijIdentificatorFactory):
@@ -123,3 +125,4 @@ class VestigingsnummerPartijIdentificatorFactory(PartijIdentificatorFactory):
         PartijIdentificatorCodeSoortObjectId.vestigingsnummer.value
     )
     partij_identificator_code_register = PartijIdentificatorCodeRegister.hr.value
+    partij_identificator_object_id = "296648875154"

--- a/src/openklant/components/klantinteracties/models/tests/factories/partijen.py
+++ b/src/openklant/components/klantinteracties/models/tests/factories/partijen.py
@@ -17,7 +17,12 @@ from openklant.components.klantinteracties.models.tests.factories.digitaal_adres
     DigitaalAdresFactory,
 )
 
-from ...constants import SoortPartij
+from ...constants import (
+    SoortPartij,
+    PartijIdentificatorCodeObjectType,
+    PartijIdentificatorCodeRegister,
+    PartijIdentificatorCodeSoortObjectId,
+)
 
 
 class PartijFactory(factory.django.DjangoModelFactory):
@@ -88,3 +93,33 @@ class PartijIdentificatorFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = PartijIdentificator
+
+
+class BsnPartijIdentificatorFactory(PartijIdentificatorFactory):
+    partij_identificator_code_objecttype = (
+        PartijIdentificatorCodeObjectType.natuurlijk_persoon.value
+    )
+    partij_identificator_code_soort_object_id = (
+        PartijIdentificatorCodeSoortObjectId.bsn.value
+    )
+    partij_identificator_code_register = PartijIdentificatorCodeRegister.brp.value
+
+
+class KvkNummerPartijIdentificatorFactory(PartijIdentificatorFactory):
+    partij_identificator_code_objecttype = (
+        PartijIdentificatorCodeObjectType.niet_natuurlijk_persoon.value
+    )
+    partij_identificator_code_soort_object_id = (
+        PartijIdentificatorCodeSoortObjectId.kvk_nummer.value
+    )
+    partij_identificator_code_register = PartijIdentificatorCodeRegister.hr.value
+
+
+class VestigingsnummerPartijIdentificatorFactory(PartijIdentificatorFactory):
+    partij_identificator_code_objecttype = (
+        PartijIdentificatorCodeObjectType.vestiging.value
+    )
+    partij_identificator_code_soort_object_id = (
+        PartijIdentificatorCodeSoortObjectId.vestigingsnummer.value
+    )
+    partij_identificator_code_register = PartijIdentificatorCodeRegister.hr.value

--- a/src/openklant/components/klantinteracties/models/tests/factories/partijen.py
+++ b/src/openklant/components/klantinteracties/models/tests/factories/partijen.py
@@ -18,10 +18,10 @@ from openklant.components.klantinteracties.models.tests.factories.digitaal_adres
 )
 
 from ...constants import (
-    SoortPartij,
     PartijIdentificatorCodeObjectType,
     PartijIdentificatorCodeRegister,
     PartijIdentificatorCodeSoortObjectId,
+    SoortPartij,
 )
 
 

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -2433,13 +2433,47 @@ paths:
           description: ''
     post:
       operationId: partijenCreate
-      description: "\n**Warnings:**\n\nHandles `partijIdentificatoren` creation with\
-        \ atomicity guarantees.\n\n- If the `UUID` is provided in the `PartijIdentificator`\
-        \ object,\nthe endpoint will treat it as an update operation for the existing\
-        \ `PartijIdentificator`,\napplying the provided data and linking the parent\
-        \ `Partij` to the new one created.\n- If the `UUID` is **not** specified,\
-        \ the system will create a new\n`PartijIdentificator` instance respecting\
-        \ all uniqueness constraints.\n    "
+      description: |2
+
+        **Warnings:**
+
+        Handles `partijIdentificatoren` creation with atomicity guarantees.
+
+        - If the `UUID` is provided in the `PartijIdentificator` object,
+        the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
+        applying the provided data and linking the parent `Partij` to the updated `PartijIdentificator`.
+        - If the `UUID` is **NOT** specified, the system will create a new
+        `PartijIdentificator` instance respecting all uniqueness constraints.
+
+        **Example:**
+
+        ```json
+        {
+          "partijIdentificatoren": [
+            {
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+              "partijIdentificator": {
+                "codeObjecttype": "niet_natuurlijk_persoon",
+                "codeSoortObjectId": "rsin",
+                "objectId": "string",
+                "codeRegister": "hr"
+              }
+            },
+            {
+              "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "string",
+                "codeRegister": "brp"
+              }
+            }
+          ]
+        }
+        ```
+
+
+        In this case, the `PartijIdentificator` with the specified `UUID` is updated and attached to the parent `Partij`,
+         while the `PartijIdentificator` without a `UUID` is created and attached to the parent `Partij`.
       summary: Maak een partij aan.
       tags:
       - partijen
@@ -2499,12 +2533,46 @@ paths:
           description: ''
     put:
       operationId: partijenUpdate
-      description: "\n**Warnings:**\n\nHandles `partijIdentificatoren` updates with\
-        \ atomicity guarantees.\n\n- If the `UUID` is provided in the `PartijIdentificator`\
-        \ object,\nthe system will update the specified instance with the new data.\n\
-        - If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator`\n\
-        objects related to the parent and `CREATE` new ones with the new passed data.\n\
-        \    "
+      description: |2
+
+        **Warnings:**
+
+        Handles `partijIdentificatoren` updates with atomicity guarantees.
+
+        - If the `UUID` is specified in the `PartijIdentificator` object,
+         the system will update the corresponding instance with the new data.
+        - If the `UUID` is **NOT** specified, the system will `DELETE` all `partijIdentificatoren`
+        objects related to the parent and `CREATE` new ones using the provided data.
+
+        **Example:**
+
+        ```json
+        {
+          "partijIdentificatoren": [
+            {
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+              "partijIdentificator": {
+                "codeObjecttype": "niet_natuurlijk_persoon",
+                "codeSoortObjectId": "rsin",
+                "objectId": "string",
+                "codeRegister": "hr"
+              }
+            },
+            {
+              "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "string",
+                "codeRegister": "brp"
+              }
+            }
+          ]
+        }
+        ```
+
+        In this case, all `partijIdentificatoren` without a specified `UUID` are deleted,
+        a new one is created due to the absence of a `UUID`, and the data for the `PartijIdentificator`
+        with the specified `UUID` is then updated.
       summary: Werk een partij in zijn geheel bij.
       parameters:
       - in: path
@@ -2532,12 +2600,46 @@ paths:
           description: ''
     patch:
       operationId: partijenPartialUpdate
-      description: "\n**Warnings:**\n\nHandles `partijIdentificatoren` updates with\
-        \ atomicity guarantees.\n\n- If the `UUID` is provided in the `PartijIdentificator`\
-        \ object,\nthe system will update the specified instance with the new data.\n\
-        - If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator`\n\
-        objects related to the parent and `CREATE` new ones with the new passed data.\n\
-        \    "
+      description: |2
+
+        **Warnings:**
+
+        Handles `partijIdentificatoren` updates with atomicity guarantees.
+
+        - If the `UUID` is specified in the `PartijIdentificator` object,
+         the system will update the corresponding instance with the new data.
+        - If the `UUID` is **NOT** specified, the system will `DELETE` all `partijIdentificatoren`
+        objects related to the parent and `CREATE` new ones using the provided data.
+
+        **Example:**
+
+        ```json
+        {
+          "partijIdentificatoren": [
+            {
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+              "partijIdentificator": {
+                "codeObjecttype": "niet_natuurlijk_persoon",
+                "codeSoortObjectId": "rsin",
+                "objectId": "string",
+                "codeRegister": "hr"
+              }
+            },
+            {
+              "partijIdentificator": {
+                "codeObjecttype": "natuurlijk_persoon",
+                "codeSoortObjectId": "bsn",
+                "objectId": "string",
+                "codeRegister": "brp"
+              }
+            }
+          ]
+        }
+        ```
+
+        In this case, all `partijIdentificatoren` without a specified `UUID` are deleted,
+        a new one is created due to the absence of a `UUID`, and the data for the `PartijIdentificator`
+        with the specified `UUID` is then updated.
       summary: Werk een partij deels bij.
       parameters:
       - in: path

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -2433,17 +2433,17 @@ paths:
           description: ''
     post:
       operationId: partijenCreate
-      description: |2
+      description: |2+
 
         **Warnings:**
 
         Handles `partijIdentificatoren` creation with atomicity guarantees.
 
-        - If the `UUID` is provided in the `PartijIdentificator` object,
-        the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
-        applying the provided data and linking the parent `Partij` to the updated `PartijIdentificator`.
+        - If the `UUID` is provided in the `partijIdentificator` object,
+        the endpoint will treat it as an update operation for the existing `partijIdentificator`,
+        applying the provided data and linking the parent `Partij` to the updated `partijIdentificator`.
         - If the `UUID` is **NOT** specified, the system will create a new
-        `PartijIdentificator` instance respecting all uniqueness constraints.
+        `partijIdentificator` instance respecting all uniqueness constraints.
 
         **Example:**
 
@@ -2472,8 +2472,39 @@ paths:
         ```
 
 
-        In this case, the `PartijIdentificator` with the specified `UUID` is updated and attached to the parent `Partij`,
-         while the `PartijIdentificator` without a `UUID` is created and attached to the parent `Partij`.
+        In this case, the `partijIdentificator` with the specified `UUID` is updated and attached to the parent `Partij`,
+         while the `partijIdentificator` without a `UUID` is created and attached to the parent `Partij`.
+
+        **Warnings:**
+
+        If you want to create a `partijIdentificator` with `vestigingsnummer`,
+        you must first ensure that a `partijIdentificator`
+        with a `kvk_nummer` already exists to assign it at the `sub_identificator_van`.
+
+        **Example:**
+
+        ```json
+        {
+          "partijIdentificatoren": [
+              {
+                  "sub_identificator_van": {"uuid": "598ffc4d-737e-49a5-b5e0-cbc438a30cb5"},
+                  "partijIdentificator": {
+                      "codeObjecttype": "vestiging",
+                      "codeSoortObjectId": "vestigingsnummer",
+                      "objectId": "string",
+                      "codeRegister": "hr",
+                  },
+              }
+          ],
+        }
+        ```
+
+        Or, to comply with the uniqueness constraints, you must first make a `POST` request
+         to create the `partijIdentificator` with `kvk_nummer`,
+        and then send a `PUT` or `PATCH` request to update the list of `partijIdentificatoren`
+         by adding the `partijIdentificator` with `vestigingsnummer`.
+        See the documentation for `PUT` and `PATCH` requests in the corresponding section.
+
       summary: Maak een partij aan.
       tags:
       - partijen
@@ -2533,16 +2564,17 @@ paths:
           description: ''
     put:
       operationId: partijenUpdate
-      description: |2
+      description: |2+
 
         **Warnings:**
 
         Handles `partijIdentificatoren` updates with atomicity guarantees.
 
-        - If the `UUID` is specified in the `PartijIdentificator` object,
+        - If the `UUID` is specified in the `partijIdentificator` object,
          the system will update the corresponding instance with the new data.
         - If the `UUID` is **NOT** specified, the system will `DELETE` all `partijIdentificatoren`
         objects related to the parent and `CREATE` new ones using the provided data.
+        This means that any `partijIdentificatoren` **not included** in the list new data will also be deleted.
 
         **Example:**
 
@@ -2570,9 +2602,13 @@ paths:
         }
         ```
 
-        In this case, all `partijIdentificatoren` without a specified `UUID` are deleted,
-        a new one is created due to the absence of a `UUID`, and the data for the `PartijIdentificator`
-        with the specified `UUID` is then updated.
+        In this case, assuming an initial state with 3 `partijIdentificatoren` for the current `Partij`,
+         the system will perform the following operations:
+          - All initial `partijIdentificatoren` not included in the list, as well as those
+          without a specified `UUID`, will be deleted.
+          - `partijIdentificator` with `codeSoortObjectId` = `rsin`, will be updated with the new data provided
+          - All other `partijIdentificatoren` without a specified `UUID` will be created.
+
       summary: Werk een partij in zijn geheel bij.
       parameters:
       - in: path
@@ -2600,16 +2636,17 @@ paths:
           description: ''
     patch:
       operationId: partijenPartialUpdate
-      description: |2
+      description: |2+
 
         **Warnings:**
 
         Handles `partijIdentificatoren` updates with atomicity guarantees.
 
-        - If the `UUID` is specified in the `PartijIdentificator` object,
+        - If the `UUID` is specified in the `partijIdentificator` object,
          the system will update the corresponding instance with the new data.
         - If the `UUID` is **NOT** specified, the system will `DELETE` all `partijIdentificatoren`
         objects related to the parent and `CREATE` new ones using the provided data.
+        This means that any `partijIdentificatoren` **not included** in the list new data will also be deleted.
 
         **Example:**
 
@@ -2637,9 +2674,13 @@ paths:
         }
         ```
 
-        In this case, all `partijIdentificatoren` without a specified `UUID` are deleted,
-        a new one is created due to the absence of a `UUID`, and the data for the `PartijIdentificator`
-        with the specified `UUID` is then updated.
+        In this case, assuming an initial state with 3 `partijIdentificatoren` for the current `Partij`,
+         the system will perform the following operations:
+          - All initial `partijIdentificatoren` not included in the list, as well as those
+          without a specified `UUID`, will be deleted.
+          - `partijIdentificator` with `codeSoortObjectId` = `rsin`, will be updated with the new data provided
+          - All other `partijIdentificatoren` without a specified `UUID` will be created.
+
       summary: Werk een partij deels bij.
       parameters:
       - in: path
@@ -5926,13 +5967,13 @@ tags:
 
     **Atomicity in Partij and PartijIdentificator**
 
-    The `Partij` endpoint handles `PartijIdentificator` objects more effectively,
+    The `Partij` endpoint handles `partijIdentificator` objects more effectively,
     allowing them to be processed within the same request.
     This ensures that both entities are handled atomically, preventing incompleteness,
-    and offering better control over the uniqueness of `PartijIdentificator` objects.
+    and offering better control over the uniqueness of `partijIdentificator` objects.
 
     For `POST`, `PATCH`, and `PUT` requests for `Partij`,
-    it is possible to send a list of `PartijIdentificator` objects.
+    it is possible to send a list of `partijIdentificator` objects.
 
 
     Deze API publiceert notificaties op het kanaal `partijen`.

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -4,7 +4,17 @@ info:
   version: 0.1.1
   description: |2
 
-    Description WIP.
+    **Warning: Difference between `PUT` and `PATCH`**
+
+    Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+    but there is a key difference in how they handle required fields:
+
+    > The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+    If any mandatory field is missing, the update will fail.
+
+    > The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+    Some mandatory fields can be left out, and the resource will only be updated with the provided data,
+    leaving other fields unchanged.
   contact:
     email: standaarden.ondersteuning@vng.nl
     url: https://zaakgerichtwerken.vng.cloud
@@ -5772,24 +5782,6 @@ tags:
 - name: categorieën
 - name: digitale adressen
 - name: interne taken
-  description: |
-    Deze API publiceert notificaties op het kanaal `internetaken`.
-
-    **Main resource**
-
-    `internetaak`
-
-
-
-    **Kenmerken**
-
-    * `nummer`: Uniek identificerend nummer dat tijdens communicatie tussen mensen kan worden gebruikt om de specifieke interne taak aan te duiden.
-    * `gevraagde_handeling`: Handeling die moet worden uitgevoerd om de taak af te ronden.
-    * `toelichting`: Toelichting die, aanvullend bij de inhoud van het klantcontact dat aanleiding gaf tot de taak en de gevraagde handeling, bijdraagt aan het kunnen afhandelen van de taak.
-    * `status`: Aanduiding van de vordering bij afhandeling van de interne taak.
-
-    **Resources en acties**
-    - `internetaak`: create, update, destroy
 - name: klanten contacten
 - name: onderwerpobjecten
 - name: partij-identificatoren
@@ -5811,5 +5803,33 @@ tags:
 
     **Resources en acties**
     - `partij`: create, update, destroy
+  description: |2
+
+    **Atomicity in Partij and PartijIdentificator**
+
+    Starting from version **2.7.0**, the `Partij` endpoint has been modified to handle
+    `PartijIdentificator` objects more effectively,
+    allowing them to be processed within the same request.
+    This ensures that both entities are handled atomically, preventing incomplete,
+    and offering better control over the uniqueness of `PartijIdentificator` objects.
+
+    For `POST`, `PATCH`, and `PUT` requests for `Partij`,
+    it is possible to send a list of `PartijIdentificator` objects.
+
+    **Warnings:**
+
+    - In all requests, `PartijIdentificator` objects should not contain the **UUID**
+    of the parent `Partij`, because it is automatically assigned.
+    - `POST` request:
+        - If the **UUID** is provided in the `PartijIdentificator` object,
+        the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
+        applying the provided data and linking the parent `Partij` to the new one created.
+        - If the **UUID** is **not** specified, the system will create a new resource
+        for the `PartijIdentificator` respecting all uniqueness constraints.
+    - `PATCH` or `PUT` requests:
+        - If the **UUID** is provided in the `PartijIdentificator` object,
+        the system will update the specified resource with the new data.
+        - If the **UUID** is **not** specified, the system will `DELETE` all `PartijIdentificator`
+        objects related to the parent and `CREATE` new ones with the passed data.
 - name: rekeningnummers
 - name: vertegenwoordigingen

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -5820,23 +5820,6 @@ tags:
 - name: onderwerpobjecten
 - name: partij-identificatoren
 - name: partijen
-  description: |
-    Deze API publiceert notificaties op het kanaal `partijen`.
-
-    **Main resource**
-
-    `partij`
-
-
-
-    **Kenmerken**
-
-    * `nummer`: Uniek identificerend nummer dat tijdens communicatie tussen mensen kan worden gebruikt om de specifieke partij aan te duiden.
-    * `interne_notitie`: Mededelingen, aantekeningen of bijzonderheden over de partij, bedoeld voor intern gebruik.
-    * `soort_partij`: Geeft aan van welke specifieke soort partij sprake is.
-
-    **Resources en acties**
-- name: partijen
   description: |2
 
     **Atomicity in Partij and PartijIdentificator**
@@ -5848,6 +5831,8 @@ tags:
 
     For `POST`, `PATCH`, and `PUT` requests for `Partij`,
     it is possible to send a list of `PartijIdentificator` objects.
+
+
     Deze API publiceert notificaties op het kanaal `partijen`.
 
     **Main resource**

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -3091,8 +3091,8 @@ components:
         partijIdentificatoren:
           type: array
           items:
-            $ref: '#/components/schemas/PartijIdentificatorForeignkey'
-          readOnly: true
+            $ref: '#/components/schemas/PartijIdentificator'
+          nullable: true
           description: Partij-identificatoren die hoorde bij deze partij.
         soortPartij:
           allOf:
@@ -3133,7 +3133,6 @@ components:
       - categorieRelaties
       - digitaleAdressen
       - indicatieActief
-      - partijIdentificatoren
       - rekeningnummers
       - soortPartij
       - url
@@ -4901,7 +4900,6 @@ components:
         uuid:
           type: string
           format: uuid
-          readOnly: true
           description: Unieke (technische) identificatiecode van de partij-identificator.
         url:
           type: string
@@ -4938,7 +4936,6 @@ components:
       required:
       - partijIdentificator
       - url
-      - uuid
     PartijIdentificatorForeignkey:
       type: object
       properties:
@@ -5455,7 +5452,6 @@ components:
         uuid:
           type: string
           format: uuid
-          readOnly: true
           description: Unieke (technische) identificatiecode van de partij-identificator.
         url:
           type: string

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -2433,7 +2433,13 @@ paths:
           description: ''
     post:
       operationId: partijenCreate
-      description: Maak een partij aan.
+      description: "\n**Warnings:**\n\nHandles `partijIdentificatoren` creation with\
+        \ atomicity guarantees.\n\n- If the `UUID` is provided in the `PartijIdentificator`\
+        \ object,\nthe endpoint will treat it as an update operation for the existing\
+        \ `PartijIdentificator`,\napplying the provided data and linking the parent\
+        \ `Partij` to the new one created.\n- If the `UUID` is **not** specified,\
+        \ the system will create a new\n`PartijIdentificator` instance respecting\
+        \ all uniqueness constraints.\n    "
       summary: Maak een partij aan.
       tags:
       - partijen
@@ -2493,7 +2499,12 @@ paths:
           description: ''
     put:
       operationId: partijenUpdate
-      description: Werk een partij in zijn geheel bij.
+      description: "\n**Warnings:**\n\nHandles `partijIdentificatoren` updates with\
+        \ atomicity guarantees.\n\n- If the `UUID` is provided in the `PartijIdentificator`\
+        \ object,\nthe system will update the specified instance with the new data.\n\
+        - If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator`\n\
+        objects related to the parent and `CREATE` new ones with the new passed data.\n\
+        \    "
       summary: Werk een partij in zijn geheel bij.
       parameters:
       - in: path
@@ -2521,7 +2532,12 @@ paths:
           description: ''
     patch:
       operationId: partijenPartialUpdate
-      description: Werk een partij deels bij.
+      description: "\n**Warnings:**\n\nHandles `partijIdentificatoren` updates with\
+        \ atomicity guarantees.\n\n- If the `UUID` is provided in the `PartijIdentificator`\
+        \ object,\nthe system will update the specified instance with the new data.\n\
+        - If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator`\n\
+        objects related to the parent and `CREATE` new ones with the new passed data.\n\
+        \    "
       summary: Werk een partij deels bij.
       parameters:
       - in: path
@@ -5782,6 +5798,24 @@ tags:
 - name: categorieën
 - name: digitale adressen
 - name: interne taken
+  description: |
+    Deze API publiceert notificaties op het kanaal `internetaken`.
+
+    **Main resource**
+
+    `internetaak`
+
+
+
+    **Kenmerken**
+
+    * `nummer`: Uniek identificerend nummer dat tijdens communicatie tussen mensen kan worden gebruikt om de specifieke interne taak aan te duiden.
+    * `gevraagde_handeling`: Handeling die moet worden uitgevoerd om de taak af te ronden.
+    * `toelichting`: Toelichting die, aanvullend bij de inhoud van het klantcontact dat aanleiding gaf tot de taak en de gevraagde handeling, bijdraagt aan het kunnen afhandelen van de taak.
+    * `status`: Aanduiding van de vordering bij afhandeling van de interne taak.
+
+    **Resources en acties**
+    - `internetaak`: create, update, destroy
 - name: klanten contacten
 - name: onderwerpobjecten
 - name: partij-identificatoren
@@ -5802,7 +5836,7 @@ tags:
     * `soort_partij`: Geeft aan van welke specifieke soort partij sprake is.
 
     **Resources en acties**
-    - `partij`: create, update, destroy
+- name: partijen
   description: |2
 
     **Atomicity in Partij and PartijIdentificator**
@@ -5814,21 +5848,20 @@ tags:
 
     For `POST`, `PATCH`, and `PUT` requests for `Partij`,
     it is possible to send a list of `PartijIdentificator` objects.
+    Deze API publiceert notificaties op het kanaal `partijen`.
 
-    **Warnings:**
+    **Main resource**
 
-    - In all requests, `PartijIdentificator` objects should not contain the **UUID**
-    of the parent `Partij`, because it is automatically assigned.
-    - `POST` request:
-        - If the **UUID** is provided in the `PartijIdentificator` object,
-        the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
-        applying the provided data and linking the parent `Partij` to the new one created.
-        - If the **UUID** is **not** specified, the system will create a new
-        `PartijIdentificator` instance respecting all uniqueness constraints.
-    - `PATCH` or `PUT` requests:
-        - If the **UUID** is provided in the `PartijIdentificator` object,
-        the system will update the specified instance with the new data.
-        - If the **UUID** is **not** specified, the system will `DELETE` all `PartijIdentificator`
-        objects related to the parent and `CREATE` new ones with the passed data.
+    `partij`
+
+
+
+    **Kenmerken**
+
+    * `nummer`: Uniek identificerend nummer dat tijdens communicatie tussen mensen kan worden gebruikt om de specifieke partij aan te duiden.
+    * `interne_notitie`: Mededelingen, aantekeningen of bijzonderheden over de partij, bedoeld voor intern gebruik.
+    * `soort_partij`: Geeft aan van welke specifieke soort partij sprake is.
+
+    **Resources en acties**
 - name: rekeningnummers
 - name: vertegenwoordigingen

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -6,13 +6,13 @@ info:
 
     **Warning: Difference between `PUT` and `PATCH`**
 
-    Both `PUT` and `PATCH` methods are used to update the fields in a resource,
+    Both `PUT` and `PATCH` methods can be used to update the fields in a resource,
     but there is a key difference in how they handle required fields:
 
-    > The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
-    If any mandatory field is missing, the update will fail.
+    * The `PUT` method requires you to specify **all mandatory fields** when updating a resource.
+    If any mandatory field is missing, the update will fail. Optional fields are left unchanged if they are not specified.
 
-    > The `PATCH` method, on the other hand, allows you to update only the fields you specify.
+    * The `PATCH` method, on the other hand, allows you to update only the fields you specify.
     Some mandatory fields can be left out, and the resource will only be updated with the provided data,
     leaving other fields unchanged.
   contact:
@@ -5807,10 +5807,9 @@ tags:
 
     **Atomicity in Partij and PartijIdentificator**
 
-    Starting from version **2.7.0**, the `Partij` endpoint has been modified to handle
-    `PartijIdentificator` objects more effectively,
+    The `Partij` endpoint handles `PartijIdentificator` objects more effectively,
     allowing them to be processed within the same request.
-    This ensures that both entities are handled atomically, preventing incomplete,
+    This ensures that both entities are handled atomically, preventing incompleteness,
     and offering better control over the uniqueness of `PartijIdentificator` objects.
 
     For `POST`, `PATCH`, and `PUT` requests for `Partij`,
@@ -5824,11 +5823,11 @@ tags:
         - If the **UUID** is provided in the `PartijIdentificator` object,
         the endpoint will treat it as an update operation for the existing `PartijIdentificator`,
         applying the provided data and linking the parent `Partij` to the new one created.
-        - If the **UUID** is **not** specified, the system will create a new resource
-        for the `PartijIdentificator` respecting all uniqueness constraints.
+        - If the **UUID** is **not** specified, the system will create a new
+        `PartijIdentificator` instance respecting all uniqueness constraints.
     - `PATCH` or `PUT` requests:
         - If the **UUID** is provided in the `PartijIdentificator` object,
-        the system will update the specified resource with the new data.
+        the system will update the specified instance with the new data.
         - If the **UUID** is **not** specified, the system will `DELETE` all `PartijIdentificator`
         objects related to the parent and `CREATE` new ones with the passed data.
 - name: rekeningnummers


### PR DESCRIPTION
Fixes #239 


**Atomicity in Partij and PartijIdentificator**

The Partij endpoint handles PartijIdentificator objects more effectively, allowing them to be processed within the same request. This ensures that both entities are handled atomically, preventing incompleteness, and offering better control over the uniqueness of PartijIdentificator objects.

For POST, PATCH, and PUT requests for Partij, it is possible to send a list of PartijIdentificator objects.

## POST
Handles `partijIdentificatoren` creation with atomicity guarantees.

- If the `UUID` is provided in the `PartijIdentificator` object,  the endpoint will treat it as an update operation for the existing `PartijIdentificator`, applying the provided data and linking the parent `Partij` to the new one created.
- If the `UUID` is **not** specified, the system will create a new `PartijIdentificator` instance respecting all uniqueness constraints.

```
    "identificatoren": []                       		-> PASS
    "identificatoren": None                     		-> PASS
    ""                                          		-> PASS
    "Identificatoren": [{PI(), PI()}]        			-> CREATE, CREATE Partij and 2 partiIdentificatoren
    "Identificatoren": [{PI(partij=1), PI()}]        	-> NOT_ALLOWED, partij_uuid must not be specified
    "Identificatoren": [{PI(uuid=1), PI()}]        		-> UPDATE and CREATE
    "Identificatoren": [{PI(uuid=1), PI(uuid=2)}]       -> UPDATE and UPDATE
```

## PUT/PATCH
Handles `partijIdentificatoren` updates with atomicity guarantees.

- If the `UUID` is provided in the `PartijIdentificator` object, the system will update the specified instance with the new data.
- If the `UUID` is **not** specified, the system will `DELETE` all `PartijIdentificator` objects related to the parent and `CREATE` new ones with the new passed data.

```
PATCH and PUT:
    "identificatoren": []                       		-> DELETE ALL 
    "identificatoren": None                     		-> PASS    
    ""                                          		-> PASS
    "identificatoren": [{PI(), PI()}]        			-> DELETE ALL for current Partij, AND CREATE 2 partiIdentificatoren
    "identificatoren": [{PI(uuid=1), PI(uuid=2)}]       -> UPDATE and UPDATE
    "identificatoren": [{PI(), PI(uuid=2)}]        		-> DELETE ALL, CREATE 1 and UPDATE 1
    # deletes all objects except those in which the uuid has been specified

```
