### PR TITLE
:green_heart: [maykinmedia/open-api-framework#116] Fix codecov publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
           SECRET_KEY: dummy
 
       - name: Publish coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   check-envvar-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
by explicitly using the CODECOV_TOKEN

Fixes maykinmedia/open-api-framework#116 partially

**Changes**

* Fix codecov publish

