### PR TITLE
:wrench: Fix bump-my-version for package/package-lock.json

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,11 @@ current_version = 2.6.0
 [bumpversion:file:README.rst]
 
 [bumpversion:file:package.json]
-search = "version": "{current_version}",
-replace = "version": "{new_version}",
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<dev>\d+)-alpha)?
+serialize =
+	{major}.{minor}.{patch}-{dev}-alpha
+	{major}.{minor}.{patch}
 
 [bumpversion:file:src/openklant/__init__.py]


### PR DESCRIPTION
Noticed that `bin/bump-my-version.sh` was not bumping the version of package.json/package-lock.json