### PR TITLE
:heavy_plus_sign: Add django-silk for performance profiling

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,8 +16,6 @@ asgiref==3.8.1
     #   django-cors-headers
 asn1crypto==1.5.1
     # via webauthn
-async-timeout==5.0.1
-    # via redis
 attrs==23.2.0
     # via
     #   glom
@@ -338,8 +336,6 @@ tornado==6.4.2
     # via flower
 typing-extensions==4.12.2
     # via
-    #   asgiref
-    #   django-solo
     #   mozilla-django-oidc-db
     #   pydantic
     #   pydantic-core

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -33,11 +33,6 @@ asn1crypto==1.5.1
     #   webauthn
 astroid==3.2.4
     # via pylint
-async-timeout==5.0.1
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   redis
 attrs==23.2.0
     # via
     #   -c requirements/base.txt
@@ -382,8 +377,6 @@ elastic-apm==6.23.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
-exceptiongroup==1.2.2
-    # via pytest
 face==20.1.1
     # via
     #   -c requirements/base.txt
@@ -758,12 +751,6 @@ sqlparse==0.5.1
     #   django
 tblib==3.0.0
     # via -r requirements/test-tools.in
-tomli==2.2.1
-    # via
-    #   black
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
     # via pylint
 tornado==6.4.2
@@ -775,10 +762,6 @@ typing-extensions==4.12.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   asgiref
-    #   astroid
-    #   black
-    #   django-solo
     #   faker
     #   mozilla-django-oidc-db
     #   pydantic

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -9,3 +9,5 @@ bump2version
 # Debug tooling
 django-debug-toolbar
 django-extensions
+django-silk
+whitenoise

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,11 +39,6 @@ astroid==3.2.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pylint
-async-timeout==5.0.1
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   redis
 attrs==23.2.0
     # via
     #   -c requirements/ci.txt
@@ -51,6 +46,8 @@ attrs==23.2.0
     #   glom
     #   jsonschema
     #   referencing
+autopep8==2.3.2
+    # via django-silk
 babel==2.15.0
     # via
     #   -c requirements/ci.txt
@@ -214,6 +211,7 @@ django==4.2.19
     #   django-sendfile2
     #   django-sessionprofile
     #   django-setup-configuration
+    #   django-silk
     #   django-simple-certmanager
     #   django-solo
     #   django-two-factor-auth
@@ -338,6 +336,8 @@ django-setup-configuration==0.7.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
+django-silk==5.3.2
+    # via -r requirements/dev.in
 django-simple-certmanager==2.3.0
     # via
     #   -c requirements/ci.txt
@@ -423,11 +423,6 @@ elastic-apm==6.23.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
-exceptiongroup==1.2.2
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   pytest
 face==20.1.1
     # via
     #   -c requirements/ci.txt
@@ -469,6 +464,8 @@ glom==23.5.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
+gprof2dot==2024.6.6
+    # via django-silk
 humanize==4.10.0
     # via
     #   -c requirements/ci.txt
@@ -662,6 +659,7 @@ pycodestyle==2.12.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   autopep8
     #   flake8
 pycparser==2.22
     # via
@@ -909,20 +907,11 @@ sqlparse==0.5.1
     #   -r requirements/ci.txt
     #   django
     #   django-debug-toolbar
+    #   django-silk
 tblib==3.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-tomli==2.2.1
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   black
-    #   build
-    #   pip-tools
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
     # via
     #   -c requirements/ci.txt
@@ -937,10 +926,6 @@ typing-extensions==4.12.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   asgiref
-    #   astroid
-    #   black
-    #   django-solo
     #   faker
     #   mozilla-django-oidc-db
     #   pydantic
@@ -1014,6 +999,8 @@ webtest==3.0.0
     #   django-webtest
 wheel==0.43.0
     # via pip-tools
+whitenoise==6.9.0
+    # via -r requirements/dev.in
 wrapt==1.16.0
     # via
     #   -c requirements/ci.txt

--- a/src/openklant/conf/dev.py
+++ b/src/openklant/conf/dev.py
@@ -98,6 +98,15 @@ DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar.panels.profiling.ProfilingPanel",
 ]
 
+#
+# DJANGO-SILK
+#
+if config("PROFILE", default=False, add_to_docs=False):
+    INSTALLED_APPS += ["silk"]
+    MIDDLEWARE = ["silk.middleware.SilkyMiddleware"] + MIDDLEWARE
+    security_index = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
+    MIDDLEWARE.insert(security_index + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
+
 # THOU SHALT NOT USE NAIVE DATETIMES
 warnings.filterwarnings(
     "error",

--- a/src/openklant/urls.py
+++ b/src/openklant/urls.py
@@ -86,3 +86,6 @@ if settings.DEBUG and apps.is_installed("debug_toolbar"):
     urlpatterns = [
         path("__debug__/", include(debug_toolbar.urls)),
     ] + urlpatterns
+
+if apps.is_installed("silk"):
+    urlpatterns += [path(r"silk/", include("silk.urls", namespace="silk"))]


### PR DESCRIPTION
I noticed that some endpoints are missing prefetch_related/select_related, resulting in a lot of queries, django-silk can be used to spot this by setting the envvar `PROFILE=yes` and navigating to `/silk` after performing requests