### PR TITLE
[#345] Fix soortPartij in Partij requests

### DIFF
--- a/src/openklant/components/klantinteracties/api/polymorphism.py
+++ b/src/openklant/components/klantinteracties/api/polymorphism.py
@@ -19,15 +19,23 @@ logger = logging.getLogger(__name__)
 
 
 class Discriminator(VngDiscriminator):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.required = kwargs.get("required", False)
+
     def to_internal_value(self, data) -> OrderedDict:
         # CUSTOM CODE: try catch to support patch call functionalities
-        try:
-            discriminator_value = data[self.discriminator_field]
-        except KeyError:
+        if self.required and self.discriminator_field not in data:
             raise serializers.ValidationError(
                 {f"{self.discriminator_field}": _("Dit veld is vereist.")}
             )
-        serializer = self.mapping.get(discriminator_value)
+
+        value = data.get(self.discriminator_field)
+        if value is None:
+            return None
+
+        serializer = self.mapping.get(value)
         if serializer is None:
             return None
 

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
@@ -159,7 +159,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [{"uuid": str(rekeningnummer.uuid)}],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "voorkeurstaal": "ndl",
             "indicatieActief": True,
             "bezoekadres": {
@@ -212,7 +212,7 @@ class PartijTests(APITestCase):
         self.assertEqual(
             data["voorkeursRekeningnummer"]["uuid"], str(rekeningnummer.uuid)
         )
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertIsNone(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -278,7 +278,7 @@ class PartijTests(APITestCase):
             self.assertIsNone(response_data["voorkeursDigitaalAdres"])
             self.assertEqual(response_data["rekeningnummers"], [])
             self.assertIsNone(response_data["voorkeursRekeningnummer"])
-            self.assertEqual(response_data["soortPartij"], "persoon")
+            self.assertEqual(response_data["soortPartij"], SoortPartij.persoon.value)
             self.assertIsNone(data["indicatieGeheimhouding"])
             self.assertEqual(response_data["voorkeurstaal"], "ndl")
             self.assertTrue(response_data["indicatieActief"])
@@ -424,7 +424,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
 
@@ -467,7 +467,7 @@ class PartijTests(APITestCase):
                 "adresregel3": "adres3",
                 "land": "NL",
             },
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "partijIdentificatie": {
                 "contactnaam": {
                     "voorletters": "P",
@@ -490,7 +490,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(response_data["voorkeursDigitaalAdres"])
         self.assertEqual(response_data["rekeningnummers"], [])
         self.assertIsNone(response_data["voorkeursRekeningnummer"])
-        self.assertEqual(response_data["soortPartij"], "persoon")
+        self.assertEqual(response_data["soortPartij"], SoortPartij.persoon.value)
         self.assertTrue(response_data["indicatieGeheimhouding"])
         self.assertEqual(response_data["voorkeurstaal"], "ndl")
         self.assertTrue(response_data["indicatieActief"])
@@ -579,7 +579,7 @@ class PartijTests(APITestCase):
                 "adresregel3": "adres3",
                 "land": "NL",
             },
-            "soortPartij": "organisatie",
+            "soortPartij": SoortPartij.organisatie.value,
             "partijIdentificatie": {
                 "naam": "Whitechapel",
                 "contactpersonen": [{"id": contactpersoon.id}],
@@ -598,7 +598,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(response_data["voorkeursDigitaalAdres"])
         self.assertEqual(response_data["rekeningnummers"], [])
         self.assertIsNone(response_data["voorkeursRekeningnummer"])
-        self.assertEqual(response_data["soortPartij"], "organisatie")
+        self.assertEqual(response_data["soortPartij"], SoortPartij.organisatie.value)
         self.assertTrue(response_data["indicatieGeheimhouding"])
         self.assertEqual(response_data["voorkeurstaal"], "ndl")
         self.assertTrue(response_data["indicatieActief"])
@@ -638,7 +638,7 @@ class PartijTests(APITestCase):
         )
 
     def test_create_contactpersoon(self):
-        organisatie = PartijFactory.create(soort_partij="organisatie")
+        organisatie = PartijFactory.create(soort_partij=SoortPartij.organisatie.value)
         list_url = reverse("klantinteracties:partij-list")
         data = {
             "nummer": "1298329191",
@@ -674,7 +674,7 @@ class PartijTests(APITestCase):
                 "adresregel3": "adres3",
                 "land": "NL",
             },
-            "soortPartij": "contactpersoon",
+            "soortPartij": SoortPartij.contactpersoon.value,
             "partijIdentificatie": {
                 "werkteVoorPartij": {
                     "uuid": organisatie.uuid,
@@ -700,7 +700,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(response_data["voorkeursDigitaalAdres"])
         self.assertEqual(response_data["rekeningnummers"], [])
         self.assertIsNone(response_data["voorkeursRekeningnummer"])
-        self.assertEqual(response_data["soortPartij"], "contactpersoon")
+        self.assertEqual(response_data["soortPartij"], SoortPartij.contactpersoon.value)
         self.assertTrue(response_data["indicatieGeheimhouding"])
         self.assertEqual(response_data["voorkeurstaal"], "ndl")
         self.assertTrue(response_data["indicatieActief"])
@@ -757,7 +757,7 @@ class PartijTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -824,7 +824,7 @@ class PartijTests(APITestCase):
         )
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -879,7 +879,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres2.uuid)},
             "rekeningnummers": [{"uuid": str(rekeningnummer2.uuid)}],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer2.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieGeheimhouding": None,
             "voorkeurstaal": "ger",
             "indicatieActief": False,
@@ -947,7 +947,7 @@ class PartijTests(APITestCase):
         self.assertEqual(
             data["voorkeursRekeningnummer"]["uuid"], str(rekeningnummer2.uuid)
         )
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertIsNone(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
         self.assertFalse(data["indicatieActief"])
@@ -1055,7 +1055,7 @@ class PartijTests(APITestCase):
                 "voorkeursDigitaalAdres": None,
                 "rekeningnummers": [],
                 "voorkeursRekeningnummer": None,
-                "soortPartij": "organisatie",
+                "soortPartij": SoortPartij.organisatie.value,
                 "indicatieGeheimhouding": False,
                 "voorkeurstaal": "ger",
                 "indicatieActief": False,
@@ -1102,7 +1102,7 @@ class PartijTests(APITestCase):
             self.assertIsNone(data["voorkeursDigitaalAdres"])
             self.assertEqual(data["rekeningnummers"], [])
             self.assertIsNone(data["voorkeursRekeningnummer"])
-            self.assertEqual(data["soortPartij"], "organisatie")
+            self.assertEqual(data["soortPartij"], SoortPartij.organisatie.value)
             self.assertFalse(data["indicatieGeheimhouding"])
             self.assertEqual(data["voorkeurstaal"], "ger")
             self.assertFalse(data["indicatieActief"])
@@ -1146,7 +1146,7 @@ class PartijTests(APITestCase):
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
         )
 
         data = {}
@@ -1182,7 +1182,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": "organisatie",
+            "soortPartij": SoortPartij.organisatie.value,
             "indicatieActief": True,
         }
 
@@ -1191,7 +1191,7 @@ class PartijTests(APITestCase):
         response_data = response.json()
 
         self.assertEqual(response_data["nummer"], "1298329191")
-        self.assertEqual(response_data["soortPartij"], "organisatie")
+        self.assertEqual(response_data["soortPartij"], SoortPartij.organisatie.value)
         self.assertEqual(
             response_data["digitaleAdressen"][0]["uuid"], str(digitaal_adres.uuid)
         )
@@ -1265,7 +1265,7 @@ class PartijTests(APITestCase):
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
         )
 
         data = {}
@@ -1273,29 +1273,16 @@ class PartijTests(APITestCase):
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
         response = self.client.patch(detail_url, data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        response_data = response.json()
-        self.assertEqual(response_data["title"], "Invalid input.")
-        self.assertEqual(response_data["code"], "invalid")
-        self.assertEqual(response_data["status"], 400)
-
-        self.assertEqual(
-            response_data["invalidParams"],
-            [
-                {
-                    "name": "soortPartij",
-                    "code": "invalid",
-                    "reason": "Dit veld is vereist.",
-                }
-            ],
-        )
-        data = {
-            "soortPartij": "organisatie",
-        }
-        response = self.client.patch(detail_url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
-        self.assertEqual(response_data["soortPartij"], "organisatie")
+        self.assertEqual(response_data["nummer"], "1298329191")
+        self.assertEqual(response_data["interneNotitie"], "interneNotitie")
+        self.assertEqual(response_data["voorkeursDigitaalAdres"], None)
+        self.assertEqual(response_data["voorkeursRekeningnummer"], None)
+        self.assertEqual(response_data["voorkeurstaal"], "ndl")
+        self.assertEqual(response_data["indicatieGeheimhouding"], True)
+        self.assertEqual(response_data["indicatieActief"], True)
+        self.assertEqual(response_data["soortPartij"], SoortPartij.persoon.value)
 
     def test_update_partij_persoon(self):
         partij = PartijFactory.create(
@@ -1303,7 +1290,7 @@ class PartijTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -1347,7 +1334,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -1401,7 +1388,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": None,
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
             "indicatieActief": False,
@@ -1449,7 +1436,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
         self.assertFalse(data["indicatieActief"])
@@ -1502,7 +1489,7 @@ class PartijTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="organisatie",
+            soort_partij=SoortPartij.organisatie.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -1540,7 +1527,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "organisatie")
+        self.assertEqual(data["soortPartij"], SoortPartij.organisatie.value)
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -1583,7 +1570,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": None,
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": "organisatie",
+            "soortPartij": SoortPartij.organisatie.value,
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
             "indicatieActief": False,
@@ -1626,7 +1613,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "organisatie")
+        self.assertEqual(data["soortPartij"], SoortPartij.organisatie.value)
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
         self.assertFalse(data["indicatieActief"])
@@ -1671,7 +1658,7 @@ class PartijTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="contactpersoon",
+            soort_partij=SoortPartij.contactpersoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -1696,7 +1683,7 @@ class PartijTests(APITestCase):
             correspondentieadres_adresregel3="adres3",
             correspondentieadres_land="NL",
         )
-        organisatie = PartijFactory.create(soort_partij="organisatie")
+        organisatie = PartijFactory.create(soort_partij=SoortPartij.organisatie.value)
         ContactpersoonFactory.create(
             partij=partij,
             werkte_voor_partij=organisatie,
@@ -1705,7 +1692,7 @@ class PartijTests(APITestCase):
             contactnaam_voorvoegsel_achternaam="",
             contactnaam_achternaam="Bozeman",
         )
-        organisatie2 = PartijFactory.create(soort_partij="organisatie")
+        organisatie2 = PartijFactory.create(soort_partij=SoortPartij.organisatie.value)
         ContactpersoonFactory.create(
             werkte_voor_partij=organisatie2,
             contactnaam_voorletters="V",
@@ -1725,7 +1712,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "contactpersoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.contactpersoon.value)
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -1783,7 +1770,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": None,
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": "contactpersoon",
+            "soortPartij": SoortPartij.contactpersoon.value,
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
             "indicatieActief": False,
@@ -1832,7 +1819,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "contactpersoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.contactpersoon.value)
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
         self.assertFalse(data["indicatieActief"])
@@ -1889,7 +1876,7 @@ class PartijTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="contactpersoon",
+            soort_partij=SoortPartij.contactpersoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -1914,7 +1901,7 @@ class PartijTests(APITestCase):
             correspondentieadres_adresregel3="adres3",
             correspondentieadres_land="NL",
         )
-        organisatie = PartijFactory.create(soort_partij="organisatie")
+        organisatie = PartijFactory.create(soort_partij=SoortPartij.organisatie.value)
         ContactpersoonFactory.create(
             partij=partij,
             werkte_voor_partij=organisatie,
@@ -1935,7 +1922,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "contactpersoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.contactpersoon.value)
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -1993,7 +1980,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": None,
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieGeheimhouding": False,
             "voorkeurstaal": "ger",
             "indicatieActief": False,
@@ -2041,7 +2028,7 @@ class PartijTests(APITestCase):
         self.assertIsNone(data["voorkeursDigitaalAdres"])
         self.assertEqual(data["rekeningnummers"], [])
         self.assertIsNone(data["voorkeursRekeningnummer"])
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertFalse(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ger")
         self.assertFalse(data["indicatieActief"])
@@ -2094,7 +2081,7 @@ class PartijTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -2194,7 +2181,7 @@ class PartijTests(APITestCase):
         data = {
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
         }
 
         response = self.client.patch(detail_url, data)
@@ -2211,7 +2198,7 @@ class PartijTests(APITestCase):
         self.assertEqual(
             data["voorkeursRekeningnummer"]["uuid"], str(rekeningnummer.uuid)
         )
-        self.assertEqual(data["soortPartij"], "persoon")
+        self.assertEqual(data["soortPartij"], SoortPartij.persoon.value)
         self.assertTrue(data["indicatieGeheimhouding"])
         self.assertEqual(data["voorkeurstaal"], "ndl")
         self.assertTrue(data["indicatieActief"])
@@ -2401,7 +2388,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                 }
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
             "partijIdentificatie": {
                 "contactnaam": {
@@ -2455,7 +2442,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [{"uuid": str(rekeningnummer.uuid)}],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
         self.assertEqual(Partij.objects.all().count(), 0)
@@ -2493,7 +2480,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
         # object with this UUID does not exist for partijIdentificatoren
@@ -2528,7 +2515,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
         response = self.client.post(self.list_url, data)
@@ -2583,7 +2570,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
 
@@ -2647,7 +2634,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
 
@@ -2673,7 +2660,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
         }
 
@@ -2703,7 +2690,6 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 },
             ],
-            "soortPartij": "organisatie",
         }
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
@@ -2713,7 +2699,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["partijIdentificatoren"]), 2)
-        self.assertEqual(response_data["soortPartij"], "organisatie")
 
     def test_invalid_create_where_partij_uuid_is_passed(self):
         digitaal_adres = DigitaalAdresFactory.create()
@@ -2740,7 +2725,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                 }
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
             "partijIdentificatie": {
                 "contactnaam": {
@@ -2766,7 +2751,7 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertEqual(Partij.objects.all().count(), 1)
 
         # PATC and PUT allow to pass identificeerdePartij
-        data["soortPartij"] = "organisatie"
+        data["soortPartij"] = SoortPartij.organisatie.value
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -2775,7 +2760,7 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["partijIdentificatoren"]), 1)
-        self.assertEqual(response_data["soortPartij"], "organisatie")
+        self.assertEqual(response_data["soortPartij"], SoortPartij.organisatie.value)
 
     def test_invalid_create_partij_identificator_globally_uniqueness(self):
         digitaal_adres = DigitaalAdresFactory.create()
@@ -2803,7 +2788,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                 }
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
             "partijIdentificatie": {
                 "contactnaam": {
@@ -2850,7 +2835,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                 partij_identificator_dict,
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
             "partijIdentificatie": {
                 "contactnaam": {
@@ -2895,7 +2880,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                 },
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
             "partijIdentificatie": {
                 "contactnaam": {
@@ -2950,7 +2935,7 @@ class NestedPartijIdentificatorTests(APITestCase):
                 },
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.persoon.value,
             "indicatieActief": True,
             "partijIdentificatie": {
                 "contactnaam": {
@@ -2981,14 +2966,14 @@ class NestedPartijIdentificatorTests(APITestCase):
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
         )
 
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
 
-        data = {"soortPartij": "organisatie"}
+        data = {}
 
         for sub_test in [
             (lambda data: data, 0),
@@ -3000,7 +2985,6 @@ class NestedPartijIdentificatorTests(APITestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response_data = response.json()
             self.assertEqual(response_data["partijIdentificatoren"], [])
-            self.assertEqual(response_data["soortPartij"], "organisatie")
             self.assertEqual(partij.partijidentificator_set.count(), sub_test[1])
 
     def test_partially_update_where_all_partij_identificatoren_have_uuid(self):
@@ -3009,7 +2993,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -3025,7 +3009,6 @@ class NestedPartijIdentificatorTests(APITestCase):
 
         # changes are only for objectId
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "uuid": str(bsn.uuid),
@@ -3063,8 +3046,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         partij = Partij.objects.get(pk=partij.pk)
 
         self.assertEqual(len(response_data["partijIdentificatoren"]), 3)
-        self.assertEqual(response_data["soortPartij"], "organisatie")
-        self.assertEqual(partij.soort_partij, "organisatie")
         new_bsn = partij.partijidentificator_set.get(
             partij_identificator_code_soort_object_id="bsn"
         )
@@ -3091,7 +3072,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -3104,7 +3085,6 @@ class NestedPartijIdentificatorTests(APITestCase):
 
         # changes are only for objectId
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "partijIdentificator": {
@@ -3130,8 +3110,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         response_data = response.json()
         partij = Partij.objects.get(pk=partij.pk)
         self.assertEqual(len(response_data["partijIdentificatoren"]), 2)
-        self.assertEqual(response_data["soortPartij"], "organisatie")
-        self.assertEqual(partij.soort_partij, "organisatie")
         new_bsn = partij.partijidentificator_set.get(
             partij_identificator_code_soort_object_id="bsn"
         )
@@ -3152,7 +3130,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -3168,7 +3146,6 @@ class NestedPartijIdentificatorTests(APITestCase):
 
         # changes are only for objectId
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "partijIdentificator": {
@@ -3205,8 +3182,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         response_data = response.json()
         partij = Partij.objects.get(pk=partij.pk)
         self.assertEqual(len(response_data["partijIdentificatoren"]), 3)
-        self.assertEqual(response_data["soortPartij"], "organisatie")
-        self.assertEqual(partij.soort_partij, "organisatie")
         new_bsn = partij.partijidentificator_set.get(
             partij_identificator_code_soort_object_id="bsn"
         )
@@ -3234,7 +3209,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -3252,7 +3227,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         )
         # changes are only for objectId
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {  # same data as bsn object, without uuid
                     "partijIdentificator": {
@@ -3279,8 +3253,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         partij = Partij.objects.get(pk=partij.pk)
 
         self.assertEqual(len(response_data["partijIdentificatoren"]), 2)
-        self.assertEqual(response_data["soortPartij"], "organisatie")
-        self.assertEqual(partij.soort_partij, "organisatie")
 
         new_bsn = partij.partijidentificator_set.get(
             partij_identificator_code_soort_object_id="bsn"
@@ -3297,7 +3269,7 @@ class NestedPartijIdentificatorTests(APITestCase):
         )
 
     def test_invalid_partially_update_globally_uniqueness(self):
-        partij_a = PartijFactory.create(soort_partij="persoon")
+        partij_a = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
         partij_b = PartijFactory.create()
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij_a.uuid)}
@@ -3309,9 +3281,8 @@ class NestedPartijIdentificatorTests(APITestCase):
         )
         self.assertTrue(partij_a.partijidentificator_set.count(), 1)
         self.assertTrue(partij_b.partijidentificator_set.count(), 1)
-        self.assertEqual(partij_a.soort_partij, "persoon")
+        self.assertEqual(partij_a.soort_partij, SoortPartij.persoon.value)
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "partijIdentificator": {
@@ -3336,10 +3307,10 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertTrue(partij_a.partijidentificator_set.count(), 1)
         self.assertTrue(partij_b.partijidentificator_set.count(), 1)
         # partij has the same data
-        self.assertEqual(partij_a.soort_partij, "persoon")
+        self.assertEqual(partij_a.soort_partij, SoortPartij.persoon.value)
 
     def test_invalid_partially_update_locally_uniqueness(self):
-        partij = PartijFactory.create(soort_partij="persoon")
+        partij = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -3348,10 +3319,9 @@ class NestedPartijIdentificatorTests(APITestCase):
         kvk_nummer = KvkNummerPartijIdentificatorFactory.create(partij=partij)
         self.assertTrue(partij.partijidentificator_set.count(), 2)
 
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
 
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {  # same data as bsn object
                     "uuid": str(bsn.uuid),
@@ -3383,7 +3353,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             "Partij identificator met deze Partij en Soort object ID bestaat al.",
         )
         # partij has the same data
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
 
     def test_update_partij_identificatoren_only_required(self):
         partij = PartijFactory.create(
@@ -3391,7 +3361,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             interne_notitie="interneNotitie",
             voorkeurs_digitaal_adres=None,
             voorkeurs_rekeningnummer=None,
-            soort_partij="persoon",
+            soort_partij=SoortPartij.persoon.value,
             indicatie_geheimhouding=True,
             voorkeurstaal="ndl",
             indicatie_actief=True,
@@ -3400,7 +3370,6 @@ class NestedPartijIdentificatorTests(APITestCase):
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [{}],
         }
         with self.subTest("invalid_put_empty_dict"):
@@ -3417,7 +3386,6 @@ class NestedPartijIdentificatorTests(APITestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "partijIdentificator": {},
@@ -3470,7 +3438,7 @@ class NestedPartijIdentificatorTests(APITestCase):
             self.assertEqual(error_soort_object_id["code"], "required")
 
     def test_invalid_update_delete_sub_identificator(self):
-        partij = PartijFactory.create(soort_partij="persoon")
+        partij = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -3482,11 +3450,10 @@ class NestedPartijIdentificatorTests(APITestCase):
             sub_identificator_van=sub_identificator_van,
         )
 
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
         self.assertEqual(Partij.objects.all().count(), 1)
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "uuid": str(vestigingsnummer.uuid),
@@ -3515,11 +3482,11 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertEqual(Partij.objects.all().count(), 1)
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         # partij has the same data
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
 
     def test_invalid_delete_sub_identificator_van_parent(self):
-        partij_a = PartijFactory.create(soort_partij="persoon")
-        partij_b = PartijFactory.create(soort_partij="persoon")
+        partij_a = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
+        partij_b = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
 
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij_a.uuid)}
@@ -3538,7 +3505,6 @@ class NestedPartijIdentificatorTests(APITestCase):
         # passes the new partijIdentificator = bsn and without specifying kvk_nummer,
         # so it should be deleted, but this is not allowed
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "partijIdentificator": {
@@ -3567,10 +3533,10 @@ class NestedPartijIdentificatorTests(APITestCase):
         partij_b.partijidentificator_set.get()
 
         # partij has the same data
-        self.assertEqual(partij_a.soort_partij, "persoon")
+        self.assertEqual(partij_a.soort_partij, SoortPartij.persoon.value)
 
     def test_invalid_update_remove_sub_identificator(self):
-        partij = PartijFactory.create(soort_partij="persoon")
+        partij = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -3582,12 +3548,11 @@ class NestedPartijIdentificatorTests(APITestCase):
             sub_identificator_van=sub_identificator_van,
         )
 
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
         self.assertEqual(Partij.objects.all().count(), 1)
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [
                 {
                     "uuid": str(sub_identificator_van.uuid),
@@ -3624,10 +3589,10 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertEqual(Partij.objects.all().count(), 1)
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
         # partij has the same data
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
 
     def test_invalid_update_delete_all(self):
-        partij = PartijFactory.create(soort_partij="persoon")
+        partij = PartijFactory.create(soort_partij=SoortPartij.persoon.value)
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -3639,12 +3604,11 @@ class NestedPartijIdentificatorTests(APITestCase):
             sub_identificator_van=sub_identificator_van,
         )
 
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)
         self.assertEqual(Partij.objects.all().count(), 1)
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
         data = {
-            "soortPartij": "organisatie",
             "partijIdentificatoren": [],
         }
         response = self.client.patch(detail_url, data)
@@ -3662,4 +3626,4 @@ class NestedPartijIdentificatorTests(APITestCase):
         self.assertEqual(PartijIdentificator.objects.all().count(), 2)
 
         # partij has the same data
-        self.assertEqual(partij.soort_partij, "persoon")
+        self.assertEqual(partij.soort_partij, SoortPartij.persoon.value)

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
@@ -424,7 +424,7 @@ class PartijTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
             "indicatieActief": True,
         }
 
@@ -1056,6 +1056,7 @@ class PartijTests(APITestCase):
                 "rekeningnummers": [],
                 "voorkeursRekeningnummer": None,
                 "soortPartij": SoortPartij.organisatie.value,
+                "partijIdentificatie": {"naam": "string"},
                 "indicatieGeheimhouding": False,
                 "voorkeurstaal": "ger",
                 "indicatieActief": False,
@@ -1183,6 +1184,7 @@ class PartijTests(APITestCase):
             "rekeningnummers": [],
             "voorkeursRekeningnummer": None,
             "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
 
@@ -1217,7 +1219,6 @@ class PartijTests(APITestCase):
 
         with self.subTest("set_fk_none"):
             data = {
-                "soort_partij": "organisatie",
                 "rekeningnummers": None,
                 "digitaleAdressen": None,
             }
@@ -1241,7 +1242,6 @@ class PartijTests(APITestCase):
         self.assertTrue(partij.rekeningnummer_set.exists())
         with self.subTest("set_fk_empty_list"):
             data = {
-                "soort_partij": "organisatie",
                 "rekeningnummers": [],
                 "digitaleAdressen": [],
             }
@@ -1598,9 +1598,7 @@ class PartijTests(APITestCase):
                 "adresregel3": "changed",
                 "land": "NL",
             },
-            "partijIdentificatie": {
-                "naam": "The Acacia Strain",
-            },
+            "partijIdentificatie": {"naam": "string"},
         }
 
         response = self.client.put(detail_url, data)
@@ -1647,10 +1645,7 @@ class PartijTests(APITestCase):
                 "land": "NL",
             },
         )
-        self.assertEqual(
-            data["partijIdentificatie"],
-            {"naam": "The Acacia Strain"},
-        )
+        self.assertEqual(data["partijIdentificatie"], {"naam": "string"})
 
     def test_update_partij_contactpersoon(self):
         partij = PartijFactory.create(
@@ -2181,7 +2176,6 @@ class PartijTests(APITestCase):
         data = {
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": SoortPartij.persoon.value,
         }
 
         response = self.client.patch(detail_url, data)
@@ -2388,16 +2382,9 @@ class NestedPartijIdentificatorTests(APITestCase):
                 }
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
-            "partijIdentificatie": {
-                "contactnaam": {
-                    "voorletters": "P",
-                    "voornaam": "Phil",
-                    "voorvoegselAchternaam": "",
-                    "achternaam": "Bozeman",
-                }
-            },
         }
 
         response = self.client.post(list_url, data)
@@ -2442,7 +2429,8 @@ class NestedPartijIdentificatorTests(APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [{"uuid": str(rekeningnummer.uuid)}],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
         self.assertEqual(Partij.objects.all().count(), 0)
@@ -2480,7 +2468,8 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
         # object with this UUID does not exist for partijIdentificatoren
@@ -2515,7 +2504,8 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
         response = self.client.post(self.list_url, data)
@@ -2570,7 +2560,8 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
 
@@ -2634,7 +2625,8 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
 
@@ -2660,7 +2652,8 @@ class NestedPartijIdentificatorTests(APITestCase):
                     },
                 }
             ],
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
         }
 
@@ -2752,6 +2745,7 @@ class NestedPartijIdentificatorTests(APITestCase):
 
         # PATC and PUT allow to pass identificeerdePartij
         data["soortPartij"] = SoortPartij.organisatie.value
+        data["partijIdentificatie"] = {"naam": "string"}
         detail_url = reverse(
             "klantinteracties:partij-detail", kwargs={"uuid": str(partij.uuid)}
         )
@@ -2788,16 +2782,9 @@ class NestedPartijIdentificatorTests(APITestCase):
                 }
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
-            "partijIdentificatie": {
-                "contactnaam": {
-                    "voorletters": "P",
-                    "voornaam": "Phil",
-                    "voorvoegselAchternaam": "",
-                    "achternaam": "Bozeman",
-                }
-            },
         }
         response = self.client.post(list_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -2835,16 +2822,9 @@ class NestedPartijIdentificatorTests(APITestCase):
                 partij_identificator_dict,
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
-            "partijIdentificatie": {
-                "contactnaam": {
-                    "voorletters": "P",
-                    "voornaam": "Phil",
-                    "voorvoegselAchternaam": "",
-                    "achternaam": "Bozeman",
-                }
-            },
         }
         response = self.client.post(list_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -2880,16 +2860,9 @@ class NestedPartijIdentificatorTests(APITestCase):
                 },
             ],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": SoortPartij.persoon.value,
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "indicatieActief": True,
-            "partijIdentificatie": {
-                "contactnaam": {
-                    "voorletters": "P",
-                    "voornaam": "Phil",
-                    "voorvoegselAchternaam": "",
-                    "achternaam": "Bozeman",
-                }
-            },
         }
         response = self.client.post(list_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/openklant/components/klantinteracties/api/tests/test_notifications.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_notifications.py
@@ -9,6 +9,7 @@ from vng_api_common.tests import reverse
 from zgw_consumers.constants import APITypes
 from zgw_consumers.models import Service
 
+from openklant.components.klantinteracties.models.constants import SoortPartij
 from openklant.components.klantinteracties.models.tests.factories import (
     ActorFactory,
     DigitaalAdresFactory,
@@ -68,7 +69,8 @@ class SendNotificationPartijTestCase(NotificationsConfigTestCase, APITestCase):
             "voorkeursDigitaalAdres": {"uuid": str(digitaal_adres.uuid)},
             "rekeningnummers": [{"uuid": str(rekeningnummer.uuid)}],
             "voorkeursRekeningnummer": {"uuid": str(rekeningnummer.uuid)},
-            "soortPartij": "persoon",
+            "soortPartij": SoortPartij.organisatie.value,
+            "partijIdentificatie": {"naam": "string"},
             "voorkeurstaal": "ndl",
             "indicatie_actief": True,
         }
@@ -90,7 +92,7 @@ class SendNotificationPartijTestCase(NotificationsConfigTestCase, APITestCase):
                 "kenmerken": {
                     "nummer": "123456789",
                     "interneNotitie": "interneNotitie",
-                    "soortPartij": "persoon",
+                    "soortPartij": SoortPartij.organisatie.value,
                 },
             }
         )
@@ -112,14 +114,16 @@ class SendNotificationPartijTestCase(NotificationsConfigTestCase, APITestCase):
                 "kenmerken": {
                     "nummer": "123456789",
                     "interneNotitie": "interneNotitie",
-                    "soortPartij": "persoon",
+                    "soortPartij": SoortPartij.organisatie.value,
                 },
             }
         )
 
     def test_send_notification_partial_update_object(self, m):
         with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.patch(self.detail_url, {"soortPartij": "persoon"})
+            response = self.client.patch(
+                self.detail_url, {"soortPartij": SoortPartij.organisatie.value}
+            )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
@@ -134,7 +138,7 @@ class SendNotificationPartijTestCase(NotificationsConfigTestCase, APITestCase):
                 "kenmerken": {
                     "nummer": "1298329191",
                     "interneNotitie": "interneNotitie",
-                    "soortPartij": "persoon",
+                    "soortPartij": SoortPartij.organisatie.value,
                 },
             }
         )


### PR DESCRIPTION
Fixes #345  and #303

- Update the Discriminator to support `required` option 