### PR TITLE
:zap: [#385] Fix prefetch_related and select_related in queryset endpoints

### DIFF
--- a/src/openklant/components/klantinteracties/api/serializers/internetaken.py
+++ b/src/openklant/components/klantinteracties/api/serializers/internetaken.py
@@ -84,13 +84,13 @@ class InterneTaakSerializer(serializers.HyperlinkedModelSerializer):
 
     def to_representation(self, instance):
         response = super().to_representation(instance)
+        actoren_query = instance.actoren.order_by("internetakenactorenthoughmodel__pk")
         response["toegewezen_aan_actor"] = ActorForeignKeySerializer(
-            instance.actoren.order_by("internetakenactorenthoughmodel__pk").first(),
-            context={**self.context},
+            actoren_query.first(), context={**self.context}
         ).data
 
         response["toegewezen_aan_actoren"] = ActorForeignKeySerializer(
-            instance.actoren.all().order_by("internetakenactorenthoughmodel__pk"),
+            actoren_query.all(),
             context={**self.context},
             many=True,
         ).data

--- a/src/openklant/components/klantinteracties/api/viewsets/actoren.py
+++ b/src/openklant/components/klantinteracties/api/viewsets/actoren.py
@@ -41,10 +41,14 @@ from openklant.components.token.permission import TokenPermissions
 class ActorViewSet(viewsets.ModelViewSet):
     """Iets dat of iemand die voor de gemeente werkzaamheden uitvoert."""
 
-    queryset = Actor.objects.order_by("-pk").select_related(
-        "geautomatiseerdeactor",
-        "medewerker",
-        "organisatorischeeenheid",
+    queryset = (
+        Actor.objects.order_by("-pk")
+        .select_related(
+            "geautomatiseerdeactor",
+            "medewerker",
+            "organisatorischeeenheid",
+        )
+        .prefetch_related("actorklantcontact_set")
     )
     serializer_class = ActorSerializer
     lookup_field = "uuid"

--- a/src/openklant/components/klantinteracties/api/viewsets/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/viewsets/klantcontacten.py
@@ -66,6 +66,8 @@ class KlantcontactViewSet(ExpandMixin, viewsets.ModelViewSet):
         "bijlage_set",
         "betrokkene_set",
         "internetaak_set",
+        "actorklantcontact_set",
+        "onderwerpobject_set",
     )
     serializer_class = KlantcontactSerializer
     lookup_field = "uuid"

--- a/src/openklant/components/klantinteracties/api/viewsets/partijen.py
+++ b/src/openklant/components/klantinteracties/api/viewsets/partijen.py
@@ -70,11 +70,16 @@ class PartijViewSet(NotificationViewSetMixin, ExpandMixin, viewsets.ModelViewSet
             "organisatie",
             "persoon",
             "contactpersoon",
+            "voorkeurs_digitaal_adres",
+            "voorkeurs_rekeningnummer",
         )
         .prefetch_related(
             "betrokkene_set",
             "digitaaladres_set",
+            "categorierelatie_set",
             "partijidentificator_set",
+            "rekeningnummer_set",
+            "vertegenwoordigende",
         )
     )
     serializer_class = PartijSerializer
@@ -246,7 +251,10 @@ class CategorieViewSet(viewsets.ModelViewSet):
 class PartijIdentificatorViewSet(viewsets.ModelViewSet):
     """Gegevens die een partij in een basisregistratie of ander extern register uniek identificeren."""
 
-    queryset = PartijIdentificator.objects.order_by("-pk").select_related("partij")
+    queryset = PartijIdentificator.objects.order_by("-pk").select_related(
+        "partij",
+        "sub_identificator_van",
+    )
     serializer_class = PartijIdentificatorSerializer
     lookup_field = "uuid"
     pagination_class = DynamicPageSizePagination


### PR DESCRIPTION
Fixes #385 
- [x] /actoren
    - Fixed, add `prefetch_related("actorklantcontact_set")`
    - 2 query for list, 4 join
- [x] /actorklantcontacten
   - ok
    - 1 query for list, 2 join
- [x] /betrokkenen
   - ok
    - 2 query for list, 2 join
- [x] /bijlagen
   - ok
    - 1 query for list, 1 join
- [x] /categorie-relaties
   - ok
    - 1 query for list, 2 join
- [x] /categorieen
    - ok
    - 2 query for list, 0 join
- [x] /digitaleadressen
    - ok
    - 1 query for list, 2 join
- [x] /internetaken
    - Fixed `to_representation` method 
    - 2 query for list + `klantinteracties_internetakenactorenthoughmodel` queries
- [x] /klantcontacten
    - ok
    - 6 query for list + `klantinteracties_medewerker` + `klantinteracties_actor` queries
- [x] /onderwerpobjecten
    - ok
    - 1 query for list, 2 join
- [x] /partij-identificatoren
    - Fixed `select_related`
    - 1 query for list, 2 join
- [x] /partijen
    - Fixed `prefetch_related` and `select_related`
    - 7 query for list, 5 join
- [x] /rekeningnummers
    - ok
    - 1 query for list, 1 join
- [x] /vertegenwoordigingen
    - ok
    - 1 query for list, 2 join
- [x] /maak-klantcontact
    - only POST
