### PR TITLE
:bug: [#368] Fix Open Klant accepteert ongeldige telefoonnummers

### DIFF
--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -4339,7 +4339,7 @@ components:
           type: string
           description: Telefoonnummer waaronder de MEDEWERKER in de regel bereikbaar
             is.
-          pattern: (0[8-9]00[0-9]{4,7})|(0[1-9][0-9]{8})|(\+[0-9]{9,20}|1400|140[0-9]{2,3})
+          pattern: ^(0[8-9]00[0-9]{4,8}|0[1-9][0-9]{8}|\+31[0-9]{10}|\+[0-9]{9,20}|00[0-9]{11}|1400|140[0-9]{2,3})$
           maxLength: 20
       required:
       - functie
@@ -4495,7 +4495,7 @@ components:
           type: string
           description: Telefoonnummer waaronder de MEDEWERKER in de regel bereikbaar
             is.
-          pattern: (0[8-9]00[0-9]{4,7})|(0[1-9][0-9]{8})|(\+[0-9]{9,20}|1400|140[0-9]{2,3})
+          pattern: ^(0[8-9]00[0-9]{4,8}|0[1-9][0-9]{8}|\+31[0-9]{10}|\+[0-9]{9,20}|00[0-9]{11}|1400|140[0-9]{2,3})$
           maxLength: 20
     PaginatedActorKlantcontactList:
       type: object

--- a/src/openklant/utils/tests/test_validators.py
+++ b/src/openklant/utils/tests/test_validators.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from openklant.utils.validators import (
     validate_bag_id,
@@ -12,7 +12,7 @@ from openklant.utils.validators import (
 )
 
 
-class ValidatorsTestCase(TestCase):
+class ValidatorsTestCase(SimpleTestCase):
     """
     Validates the functions defined in ``utils.validators`` module.
     """

--- a/src/openklant/utils/tests/test_validators.py
+++ b/src/openklant/utils/tests/test_validators.py
@@ -83,6 +83,8 @@ class ValidatorsTestCase(TestCase):
             "1400",
             "14012",
             "14079",
+            "0313028612",
+            "0313028600",
         ]
         invalid_phone_numbers = [
             "0695azerty",
@@ -91,6 +93,11 @@ class ValidatorsTestCase(TestCase):
             "onetwothreefour",
             "020 753 0523",
             "+311234",
+            "031302860000",
+            "03130286000",
+            "00311234567",
+            "00313223344555",
+            "316123456789",
         ]
         for invalid_phone_number in invalid_phone_numbers:
             with self.subTest(invalid_phone_number):

--- a/src/openklant/utils/validators.py
+++ b/src/openklant/utils/validators.py
@@ -39,7 +39,15 @@ def validate_charfield_entry(value, allow_apostrophe=False):
 
 
 validate_phone_number = RegexValidator(
-    regex="(0[8-9]00[0-9]{4,7})|(0[1-9][0-9]{8})|(\\+[0-9]{9,20}|1400|140[0-9]{2,3})",
+    regex=r"^("
+    r"0[8-9]00[0-9]{4,8}"  # starting with 08 or 09, followed by 00 and then 4 to 8 digits
+    r"|0[1-9][0-9]{8}"  # starting with 0, followed by a digit from 1-9 and then exactly 8 digits
+    r"|\+31[0-9]{10}"  # starting with +31 followed by 10 digits (Dutch format)
+    r"|\+[0-9]{9,20}"  # starting with + followed by 9 to 20 digits (international numbers)
+    r"|00[0-9]{11}"  # starting with 00, followed by 11 digits
+    r"|1400"  # specific short number for services
+    r"|140[0-9]{2,3}"  # starting with 140 and followed by 2 or 3 digits
+    r")$",
     message=_("Het opgegeven telefoonnummer is ongeldig."),
 )
 


### PR DESCRIPTION
Fixes #368

Changes 

- ensures international format has exactly 9 digits after country code

