### PR TITLE
:zap: [#378] Improve performance partij admin

### DIFF
--- a/src/openklant/components/klantinteracties/admin/partijen.py
+++ b/src/openklant/components/klantinteracties/admin/partijen.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.contrib import admin
-from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from openklant.components.klantinteracties.models.rekeningnummers import Rekeningnummer
@@ -32,32 +31,51 @@ class PartijAdminForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
 
-        voorkeurs_digitaal_adres = cleaned_data.get("voorkeurs_digitaal_adres")
-        voorkeurs_rekeningnummer = cleaned_data.get("voorkeurs_rekeningnummer")
-
-        if voorkeurs_digitaal_adres:
-            if (
-                voorkeurs_digitaal_adres
-                not in DigitaalAdres.objects.filter(partij=self.instance).all()
-            ):
-                raise ValidationError(
+        if voorkeurs_digitaal_adres := cleaned_data.get("voorkeurs_digitaal_adres"):
+            if not self.instance.pk:
+                raise forms.ValidationError(
                     {
-                        "voorkeurs_digitaal_adres": _(
-                            "Het voorkeurs adres moet een gelinkte digitaal adres zijn."
-                        )
+                        "voorkeurs_digitaal_adres": [
+                            _(
+                                "Om de `voorkeurs_digitaal_adres` te selecteren,"
+                                " moet je eerst de Partij aanmaken en opslaan."
+                            )
+                        ]
                     }
                 )
 
-        if voorkeurs_rekeningnummer:
-            if (
-                voorkeurs_rekeningnummer
-                not in Rekeningnummer.objects.filter(partij=self.instance).all()
-            ):
-                raise ValidationError(
+            if voorkeurs_digitaal_adres not in self.instance.digitaaladres_set.all():
+                raise forms.ValidationError(
                     {
-                        "voorkeurs_rekeningnummer": _(
-                            "Het voorkeurs rekeningnummer moet een gelinkte rekeningnummer zijn."
-                        )
+                        "voorkeurs_digitaal_adres": [
+                            _(
+                                "Het voorkeurs adres moet een gelinkte digitaal adres zijn."
+                            )
+                        ]
+                    }
+                )
+
+        if voorkeurs_rekeningnummer := cleaned_data.get("voorkeurs_rekeningnummer"):
+            if not self.instance.pk:
+                raise forms.ValidationError(
+                    {
+                        "voorkeurs_rekeningnummer": [
+                            _(
+                                "Om de `voorkeurs_rekeningnummer` te selecteren,"
+                                " moet je eerst de Partij aanmaken en opslaan."
+                            )
+                        ]
+                    }
+                )
+
+            if voorkeurs_rekeningnummer not in self.instance.rekeningnummer_set.all():
+                raise forms.ValidationError(
+                    {
+                        "voorkeurs_rekeningnummer": [
+                            _(
+                                "Het voorkeurs rekeningnummer moet een gelinkte rekeningnummer zijn."
+                            )
+                        ]
                     }
                 )
 

--- a/src/openklant/components/klantinteracties/admin/partijen.py
+++ b/src/openklant/components/klantinteracties/admin/partijen.py
@@ -257,33 +257,38 @@ class PartijAdmin(admin.ModelAdmin):
             super()
             .get_queryset(request)
             .select_related(
+                "voorkeurs_rekeningnummer",
                 "voorkeurs_digitaal_adres",
+                "organisatie",
+                "persoon",
+                "contactpersoon",
             )
         )
 
     @admin.display(empty_value="---")
     def get_name(self, obj):
         match obj.soort_partij:
-            case SoortPartij.persoon:
+            case SoortPartij.persoon.value:
                 return self.get_personen(obj)
-            case SoortPartij.contactpersoon:
+            case SoortPartij.contactpersoon.value:
                 return self.get_contactpersonen(obj)
-            case SoortPartij.organisatie:
+            case SoortPartij.organisatie.value:
                 return self.get_organisaties(obj)
 
     get_name.short_description = _("naam")
 
     def get_personen(self, obj):
-        if persoon := obj.persoon:
-            return persoon.get_full_name()
+        return obj.persoon.get_full_name() if hasattr(obj, "persoon") else "---"
 
     def get_contactpersonen(self, obj):
-        if contactpersoon := obj.contactpersoon:
-            return contactpersoon.get_full_name()
+        return (
+            obj.contactpersoon.get_full_name()
+            if hasattr(obj, "contactpersoon")
+            else "---"
+        )
 
     def get_organisaties(self, obj):
-        if organisatie := obj.organisatie:
-            return organisatie.naam
+        return obj.organisatie.naam if hasattr(obj, "organisatie") else "---"
 
 
 @admin.register(Categorie)

--- a/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
+++ b/src/openklant/components/klantinteracties/api/tests/partijen/test_partij.py
@@ -2289,34 +2289,6 @@ class PartijTests(APITestCase):
             received_adressen[0]["url"], f"http://testserver{expected_url}"
         )
 
-    def test_str_representation_persoon(self):
-        persoon = PersoonFactory.create()
-        partij = persoon.partij
-
-        self.assertEqual(str(partij), f"{persoon} ({partij.nummer})")
-
-    def test_str_representation_organisatie(self):
-        organisatie = OrganisatieFactory.create()
-        partij = organisatie.partij
-
-        self.assertEqual(str(partij), f"{organisatie} ({partij.nummer})")
-
-    def test_str_representation_contactpersoon(self):
-        contactpersoon = ContactpersoonFactory.create()
-        partij = contactpersoon.partij
-
-        self.assertEqual(str(partij), f"{contactpersoon} ({partij.nummer})")
-
-    def test_str_representation_other(self):
-        partij = PartijFactory.create(soort_partij=SoortPartij.persoon)
-
-        self.assertEqual(str(partij), partij.nummer)
-
-    def test_str_representation_random_type(self):
-        partij = PartijFactory.create(soort_partij="random")
-
-        self.assertEqual(str(partij), partij.nummer)
-
 
 class NestedPartijIdentificatorTests(APITestCase):
     list_url = reverse_lazy("klantinteracties:partij-list")

--- a/src/openklant/components/klantinteracties/models/partijen.py
+++ b/src/openklant/components/klantinteracties/models/partijen.py
@@ -104,20 +104,6 @@ class Partij(APIMixin, BezoekadresMixin, CorrespondentieadresMixin):
         return super().save(*args, **kwargs)
 
     def __str__(self):
-        if soort_partij := self.soort_partij:
-            match (soort_partij):
-                case SoortPartij.persoon:
-                    partij = Persoon.objects.filter(partij=self).first()
-                case SoortPartij.organisatie:
-                    partij = Organisatie.objects.filter(partij=self).first()
-                case SoortPartij.contactpersoon:
-                    partij = Contactpersoon.objects.filter(partij=self).first()
-                case _:
-                    return self.nummer
-
-            if partij:
-                return f"{partij} ({self.nummer})"
-
         return self.nummer
 
 

--- a/src/openklant/components/klantinteracties/tests/test_admin.py
+++ b/src/openklant/components/klantinteracties/tests/test_admin.py
@@ -138,44 +138,75 @@ class PartijAdminTests(WebTest):
         self.assertIsNone(adres.betrokkene)
 
     def test_voorkeurs_digitaal_adres_invalid(self):
-        partij = PartijFactory.create(soort_partij=SoortPartij.persoon)
         invalid_digitaal_adres = DigitaalAdresFactory.create()
 
-        form = PartijAdminForm(
-            data={
-                "uuid": uuid4(),
-                "voorkeurs_digitaal_adres": invalid_digitaal_adres.id,
-                "soort_partij": partij.soort_partij,
-            },
-            instance=partij,
-        )
+        with self.subTest("no_instance"):
+            form = PartijAdminForm(
+                data={
+                    "uuid": uuid4(),
+                    "voorkeurs_digitaal_adres": invalid_digitaal_adres.id,
+                    "soort_partij": SoortPartij.persoon,
+                }
+            )
 
-        self.assertFalse(form.is_valid())
-        self.assertIn("voorkeurs_digitaal_adres", form.errors)
-        self.assertIn(
-            "Het voorkeurs adres moet een gelinkte digitaal adres zijn.",
-            form.errors["voorkeurs_digitaal_adres"],
-        )
+            self.assertFalse(form.is_valid())
+            self.assertEqual(
+                form.errors["voorkeurs_digitaal_adres"][0],
+                "Om de `voorkeurs_digitaal_adres` te selecteren, moet je eerst de Partij aanmaken en opslaan.",
+            )
+
+        with self.subTest("with_instance"):
+            partij = PartijFactory.create(soort_partij=SoortPartij.persoon)
+            form = PartijAdminForm(
+                data={
+                    "uuid": uuid4(),
+                    "voorkeurs_digitaal_adres": invalid_digitaal_adres.id,
+                    "soort_partij": SoortPartij.persoon,
+                },
+                instance=partij,
+            )
+
+            self.assertFalse(form.is_valid())
+            self.assertEqual(
+                form.errors["voorkeurs_digitaal_adres"][0],
+                "Het voorkeurs adres moet een gelinkte digitaal adres zijn.",
+            )
 
     def test_voorkeurs_rekeningnummer_invalid(self):
         partij = PartijFactory.create()
         invalid_rekeningnummer = RekeningnummerFactory.create()
 
-        form = PartijAdminForm(
-            data={
-                "uuid": uuid4(),
-                "voorkeurs_rekeningnummer": invalid_rekeningnummer.id,
-                "soort_partij": partij.soort_partij,
-            },
-            instance=partij,
-        )
+        with self.subTest("no_instance"):
+            form = PartijAdminForm(
+                data={
+                    "uuid": uuid4(),
+                    "voorkeurs_rekeningnummer": invalid_rekeningnummer.id,
+                    "soort_partij": SoortPartij.persoon,
+                },
+            )
 
-        self.assertFalse(form.is_valid())
-        self.assertIn("voorkeurs_rekeningnummer", form.errors)
-        self.assertIn(
-            "Het voorkeurs rekeningnummer moet een gelinkte rekeningnummer zijn.",
-            form.errors["voorkeurs_rekeningnummer"],
-        )
+            self.assertFalse(form.is_valid())
+            self.assertEqual(
+                form.errors["voorkeurs_rekeningnummer"][0],
+                "Om de `voorkeurs_rekeningnummer` te selecteren, moet je eerst de Partij aanmaken en opslaan.",
+            )
+
+        with self.subTest("with_instance"):
+            partij = PartijFactory.create()
+            form = PartijAdminForm(
+                data={
+                    "uuid": uuid4(),
+                    "voorkeurs_rekeningnummer": invalid_rekeningnummer.id,
+                    "soort_partij": SoortPartij.persoon,
+                },
+                instance=partij,
+            )
+
+            self.assertFalse(form.is_valid())
+            self.assertEqual(
+                form.errors["voorkeurs_rekeningnummer"][0],
+                "Het voorkeurs rekeningnummer moet een gelinkte rekeningnummer zijn.",
+            )
 
 
 @disable_admin_mfa()


### PR DESCRIPTION
Fixes #378 

**Changes**

- Improved validation of the admin form as it was done before (using reference to related objects).
- And added a new validation: because the data `voorkeurs_digitaal_adres` and `voorkeurs_rekeningnummer`, should be added after the creation of `partij (instance)`, otherwise the relationships don't exist.
- Simplified `partij.__str__()`
