### PR TITLE
:safety_vest: warn users if landcode is correct but lowercase

### DIFF
--- a/src/openklant/utils/tests/test_validators.py
+++ b/src/openklant/utils/tests/test_validators.py
@@ -185,7 +185,6 @@ class ValidatorsTestCase(SimpleTestCase):
             "10",
             "ZZ",
             "1Z",
-            "nl",
         ]
         for code in invalid_codes:
             self.assertRaisesMessage(
@@ -196,3 +195,17 @@ class ValidatorsTestCase(SimpleTestCase):
             )
 
         validate_country("NL")
+
+    def test_validate_country_casing_suggestion(self):
+        invalid_codes = [
+            "gb",
+            "nl",
+        ]
+        for code in invalid_codes:
+            self.assertRaisesMessage(
+                ValidationError,
+                "Ongeldige landcode, de code moet behoren tot de ISO 3166-standaard."
+                f" Bedoelde u {code.upper()}",
+                validate_country,
+                code,
+            )

--- a/src/openklant/utils/validators.py
+++ b/src/openklant/utils/validators.py
@@ -13,9 +13,17 @@ def validate_country(value: str) -> None:
     :param value:
     :return: None if validation passed. Otherwise, raises a ``ValidationError`` exception.
     """
-    if value not in ISO_3166_1_ALPHA2_COUNTRY_CODES:
+    upper_value = value.upper()
+    if upper_value not in ISO_3166_1_ALPHA2_COUNTRY_CODES:
         raise ValidationError(
             _("Ongeldige landcode, de code moet behoren tot de ISO 3166-standaard")
+        )
+    elif value != upper_value:
+        raise ValidationError(
+            _(
+                "Ongeldige landcode, de code moet behoren tot de ISO 3166-standaard."
+                " Bedoelde u {country_upper}?"
+            ).format(country_upper=upper_value)
         )
 
 


### PR DESCRIPTION
Fixes #470 

**Changes**

Change the countrycode validation message to warn the user if their countrycode is in the incorrect case.

