### PR TITLE
:sparkles: [#419] add was_klantcontact filter to onderwerpobjecten API

### DIFF
--- a/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
@@ -11,6 +11,7 @@ from openklant.components.klantinteracties.models.actoren import ActorKlantconta
 from openklant.components.klantinteracties.models.klantcontacten import (
     Betrokkene,
     Klantcontact,
+    Onderwerpobject,
 )
 from openklant.components.utils.filters import ExpandFilter, URLViewFilter
 
@@ -290,13 +291,11 @@ class BetrokkeneFilterSet(FilterSet):
 
 class ActorKlantcontactFilterSet(FilterSet):
     actor__url = URLViewFilter(
-        help_text=_("Zoek actor klantcontract object op basis van het actor url"),
+        help_text=_("Zoek actor klantcontact object op basis van het actor url"),
         field_name="actor__uuid",
     )
     klantcontact__url = URLViewFilter(
-        help_text=_(
-            "Zoek actor klantcontract object op basis van het klantcontact url"
-        ),
+        help_text=_("Zoek actor klantcontact object op basis van het klantcontact url"),
         field_name="klantcontact__uuid",
     )
 
@@ -307,4 +306,22 @@ class ActorKlantcontactFilterSet(FilterSet):
             "actor__url",
             "klantcontact__uuid",
             "klantcontact__url",
+        )
+
+
+class OnderwerpObjectFilterSet(FilterSet):
+    was_klantcontact__url = URLViewFilter(
+        help_text=_("Zoek klantcontact object op basis van het klantcontact url"),
+        field_name="was_klantcontact__uuid",
+    )
+
+    class Meta:
+        model = Onderwerpobject
+        fields = (
+            "onderwerpobjectidentificator_code_objecttype",
+            "onderwerpobjectidentificator_code_register",
+            "onderwerpobjectidentificator_code_soort_object_id",
+            "onderwerpobjectidentificator_object_id",
+            "was_klantcontact__uuid",
+            "was_klantcontact__url",
         )

--- a/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
@@ -310,6 +310,11 @@ class ActorKlantcontactFilterSet(FilterSet):
 
 
 class OnderwerpObjectFilterSet(FilterSet):
+    klantcontact__url = URLViewFilter(
+        help_text=_("Zoek klantcontact object op basis van het klantcontact url"),
+        field_name="klantcontact__uuid",
+    )
+
     was_klantcontact__url = URLViewFilter(
         help_text=_("Zoek klantcontact object op basis van het klantcontact url"),
         field_name="was_klantcontact__uuid",
@@ -322,6 +327,8 @@ class OnderwerpObjectFilterSet(FilterSet):
             "onderwerpobjectidentificator_code_register",
             "onderwerpobjectidentificator_code_soort_object_id",
             "onderwerpobjectidentificator_object_id",
+            "klantcontact__uuid",
+            "klantcontact__url",
             "was_klantcontact__uuid",
             "was_klantcontact__url",
         )

--- a/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/filterset/klantcontacten.py
@@ -310,13 +310,25 @@ class ActorKlantcontactFilterSet(FilterSet):
 
 
 class OnderwerpObjectFilterSet(FilterSet):
-    klantcontact__url = URLViewFilter(
-        help_text=_("Zoek klantcontact object op basis van het klantcontact url"),
+    klantcontact__uuid = filters.UUIDFilter(
+        help_text=_("Zoek onderwerpobject object op basis van het klantcontact uuid"),
         field_name="klantcontact__uuid",
     )
 
+    klantcontact__url = URLViewFilter(
+        help_text=_("Zoek onderwerpobject op basis van het klantcontact url"),
+        field_name="klantcontact__uuid",
+    )
+
+    was_klantcontact__uuid = filters.UUIDFilter(
+        help_text=_(
+            "Zoek onderwerpobject object op basis van het was_klantcontact uuid"
+        ),
+        field_name="was_klantcontact__uuid",
+    )
+
     was_klantcontact__url = URLViewFilter(
-        help_text=_("Zoek klantcontact object op basis van het klantcontact url"),
+        help_text=_("Zoek onderwerpobject op basis van het was_klantcontact url"),
         field_name="was_klantcontact__uuid",
     )
 
@@ -327,8 +339,4 @@ class OnderwerpObjectFilterSet(FilterSet):
             "onderwerpobjectidentificator_code_register",
             "onderwerpobjectidentificator_code_soort_object_id",
             "onderwerpobjectidentificator_object_id",
-            "klantcontact__uuid",
-            "klantcontact__url",
-            "was_klantcontact__uuid",
-            "was_klantcontact__url",
         )

--- a/src/openklant/components/klantinteracties/api/tests/test_klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_klantcontacten.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.utils.translation import gettext as _
 
 from rest_framework import status
@@ -1563,17 +1565,22 @@ class OnderwerpobjectTests(APITestCase):
     def test_filter_onderwerpobject_by_all_identificator_fields(self):
         list_url = reverse("klantinteracties:onderwerpobject-list")
 
+        klantcontact_uuid_a = uuid.uuid4()
+        klantcontact_uuid_b = uuid.uuid4()
+
         obj = OnderwerpobjectFactory.create(
             onderwerpobjectidentificator_code_objecttype="typeA",
             onderwerpobjectidentificator_code_soort_object_id="soortA",
             onderwerpobjectidentificator_object_id="idA",
             onderwerpobjectidentificator_code_register="regA",
+            was_klantcontact__uuid=klantcontact_uuid_a,
         )
         OnderwerpobjectFactory.create(
             onderwerpobjectidentificator_code_objecttype="typeB",
             onderwerpobjectidentificator_code_soort_object_id="soortB",
             onderwerpobjectidentificator_object_id="idB",
             onderwerpobjectidentificator_code_register="regB",
+            was_klantcontact__uuid=klantcontact_uuid_b,
         )
 
         response = self.client.get(list_url)
@@ -1581,11 +1588,17 @@ class OnderwerpobjectTests(APITestCase):
         data = response.json()
         self.assertEqual(len(data["results"]), 2)
 
+        klantcontact_url_a = reverse(
+            "klantinteracties:klantcontact-detail", kwargs={"uuid": klantcontact_uuid_a}
+        )
+
         filters = {
             "onderwerpobjectidentificatorCodeObjecttype": "typeA",
             "onderwerpobjectidentificatorCodeSoortObjectId": "soortA",
             "onderwerpobjectidentificatorObjectId": "idA",
             "onderwerpobjectidentificatorCodeRegister": "regA",
+            "wasKlantcontact__uuid": klantcontact_uuid_a,
+            "wasKlantcontact__url": "https://testserver.com" + klantcontact_url_a,
         }
 
         for key, value in filters.items():

--- a/src/openklant/components/klantinteracties/api/tests/test_klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/tests/test_klantcontacten.py
@@ -1568,25 +1568,35 @@ class OnderwerpobjectTests(APITestCase):
         klantcontact_uuid_a = uuid.uuid4()
         klantcontact_uuid_b = uuid.uuid4()
 
+        was_klantcontact_uuid_a = uuid.uuid4()
+        was_klantcontact_uuid_b = uuid.uuid4()
+
         obj = OnderwerpobjectFactory.create(
             onderwerpobjectidentificator_code_objecttype="typeA",
             onderwerpobjectidentificator_code_soort_object_id="soortA",
             onderwerpobjectidentificator_object_id="idA",
             onderwerpobjectidentificator_code_register="regA",
-            was_klantcontact__uuid=klantcontact_uuid_a,
+            klantcontact__uuid=klantcontact_uuid_a,
+            was_klantcontact__uuid=was_klantcontact_uuid_a,
         )
         OnderwerpobjectFactory.create(
             onderwerpobjectidentificator_code_objecttype="typeB",
             onderwerpobjectidentificator_code_soort_object_id="soortB",
             onderwerpobjectidentificator_object_id="idB",
             onderwerpobjectidentificator_code_register="regB",
-            was_klantcontact__uuid=klantcontact_uuid_b,
+            klantcontact__uuid=klantcontact_uuid_b,
+            was_klantcontact__uuid=was_klantcontact_uuid_b,
         )
 
         response = self.client.get(list_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(len(data["results"]), 2)
+
+        was_klantcontact_url_a = reverse(
+            "klantinteracties:klantcontact-detail",
+            kwargs={"uuid": was_klantcontact_uuid_a},
+        )
 
         klantcontact_url_a = reverse(
             "klantinteracties:klantcontact-detail", kwargs={"uuid": klantcontact_uuid_a}
@@ -1597,8 +1607,10 @@ class OnderwerpobjectTests(APITestCase):
             "onderwerpobjectidentificatorCodeSoortObjectId": "soortA",
             "onderwerpobjectidentificatorObjectId": "idA",
             "onderwerpobjectidentificatorCodeRegister": "regA",
-            "wasKlantcontact__uuid": klantcontact_uuid_a,
-            "wasKlantcontact__url": "https://testserver.com" + klantcontact_url_a,
+            "wasKlantcontact__uuid": was_klantcontact_uuid_a,
+            "wasKlantcontact__url": "https://testserver.com" + was_klantcontact_url_a,
+            "klantcontact__uuid": klantcontact_uuid_a,
+            "klantcontact__url": "https://testserver.com" + klantcontact_url_a,
         }
 
         for key, value in filters.items():

--- a/src/openklant/components/klantinteracties/api/viewsets/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/api/viewsets/klantcontacten.py
@@ -11,6 +11,7 @@ from openklant.components.klantinteracties.api.filterset.klantcontacten import (
     BetrokkeneFilterSet,
     KlantcontactDetailFilterSet,
     KlantcontactFilterSet,
+    OnderwerpObjectFilterSet,
 )
 from openklant.components.klantinteracties.api.serializers.klantcontacten import (
     ActorKlantcontactSerializer,
@@ -287,12 +288,7 @@ class OnderwerpobjectViewSet(viewsets.ModelViewSet):
     serializer_class = OnderwerpobjectSerializer
     lookup_field = "uuid"
     pagination_class = DynamicPageSizePagination
-    filterset_fields = [
-        "onderwerpobjectidentificator_code_objecttype",
-        "onderwerpobjectidentificator_code_register",
-        "onderwerpobjectidentificator_code_soort_object_id",
-        "onderwerpobjectidentificator_object_id",
-    ]
+    filterset_class = OnderwerpObjectFilterSet
     authentication_classes = (TokenAuthentication,)
     permission_classes = (TokenPermissions,)
 

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -227,7 +227,7 @@ paths:
         schema:
           type: string
           format: uri
-        description: Zoek actor klantcontract object op basis van het actor url
+        description: Zoek actor klantcontact object op basis van het actor url
       - in: query
         name: actor__uuid
         schema:
@@ -239,7 +239,7 @@ paths:
         schema:
           type: string
           format: uri
-        description: Zoek actor klantcontract object op basis van het klantcontact
+        description: Zoek actor klantcontact object op basis van het klantcontact
           url
       - in: query
         name: klantcontact__uuid
@@ -2155,6 +2155,18 @@ paths:
         description: 'Het aantal resultaten terug te geven per pagina. (default: 100).'
         schema:
           type: integer
+      - in: query
+        name: wasKlantcontact__url
+        schema:
+          type: string
+          format: uri
+        description: Zoek klantcontact object op basis van het klantcontact url
+      - in: query
+        name: wasKlantcontact__uuid
+        schema:
+          type: string
+          format: uuid
+        description: Unieke (technische) identificatiecode van de betrokkene bij klantcontact.
       tags:
       - onderwerpobjecten
       security:

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -2125,13 +2125,13 @@ paths:
         schema:
           type: string
           format: uri
-        description: Zoek klantcontact object op basis van het klantcontact url
+        description: Zoek onderwerpobject op basis van het klantcontact url
       - in: query
         name: klantcontact__uuid
         schema:
           type: string
           format: uuid
-        description: Unieke (technische) identificatiecode van de betrokkene bij klantcontact.
+        description: Zoek onderwerpobject object op basis van het klantcontact uuid
       - in: query
         name: onderwerpobjectidentificatorCodeObjecttype
         schema:
@@ -2172,13 +2172,14 @@ paths:
         schema:
           type: string
           format: uri
-        description: Zoek klantcontact object op basis van het klantcontact url
+        description: Zoek onderwerpobject op basis van het was_klantcontact url
       - in: query
         name: wasKlantcontact__uuid
         schema:
           type: string
           format: uuid
-        description: Unieke (technische) identificatiecode van de betrokkene bij klantcontact.
+        description: Zoek onderwerpobject object op basis van het was_klantcontact
+          uuid
       tags:
       - onderwerpobjecten
       security:

--- a/src/openklant/components/klantinteracties/openapi.yaml
+++ b/src/openklant/components/klantinteracties/openapi.yaml
@@ -2121,6 +2121,18 @@ paths:
       summary: Alle onderwerpobject opvragen.
       parameters:
       - in: query
+        name: klantcontact__url
+        schema:
+          type: string
+          format: uri
+        description: Zoek klantcontact object op basis van het klantcontact url
+      - in: query
+        name: klantcontact__uuid
+        schema:
+          type: string
+          format: uuid
+        description: Unieke (technische) identificatiecode van de betrokkene bij klantcontact.
+      - in: query
         name: onderwerpobjectidentificatorCodeObjecttype
         schema:
           type: string


### PR DESCRIPTION
Fixes #419 

**Changes**
- adds was_klantcontact__uuid & was_klantcontact__url filters to onderwerpobjecten API.
