### PR TITLE
:recycle: [maykinmedia/open-api-framework#83] Replace OAF config helper with config helper from maykin-common

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,30 +101,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  check-envvar-docs:
-    runs-on: ubuntu-latest
-    name: Documentation build
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Set up backend environment
-        uses: maykinmedia/setup-django-backend@a9abe0987130ed667fa09ce177a5ae0bd153aed1 # v1.3
-        with:
-          python-version: '3.12'
-          setup-node: false
-
-      - name: Generate environment variable documentation using OAf and check if it was updated
-        run: |
-          bin/generate_envvar_docs.sh
-          changes=$(git diff docs/installation/config/env_configuration.rst)
-          if [ ! -z "$changes" ]; then
-              echo $changes
-              echo "Please update the environment documentation by running \`bin/generate_envvar_docs.sh\`"
-              exit 1
-          fi
-
   store-reusable-workflow-vars:
     name: create values which can be passed through a reusable workflow
     runs-on: ubuntu-latest

--- a/bin/generate_envvar_docs.sh
+++ b/bin/generate_envvar_docs.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Generates the documentation for environment variables
-src/manage.py generate_envvar_docs --file docs/installation/config/env_configuration.rst --exclude-group Celery

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     "vng_api_common.diagrams.uml_images",
     "sphinx_tabs.tabs",
     "recommonmark",
+    "maykin_common.documentation.config_directives",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/installation/config/env_configuration.rst
+++ b/docs/installation/config/env_configuration.rst
@@ -4,121 +4,14 @@
 Environment configuration reference
 ===================================
 
-
-Open Klant can be ran both as a Docker container or directly on a VPS or
-dedicated server. It relies on other services, such as database and cache
-backends, which can be configured through environment variables.
-
+Open Klant can be ran both as a Docker container or directly on a VPS or dedicated server.
+It relies on other services, such as database and cache backends,
+which can be configured through environment variables.
 
 Available environment variables
 ===============================
 
-
-Required
---------
-
-* ``SECRET_KEY``: Secret key that's used for certain cryptographic utilities. .
-* ``ALLOWED_HOSTS``: a comma separated (without spaces!) list of domains that serve the installation. Used to protect against Host header attacks. Defaults to: ``(empty string)``.
-* ``CACHE_DEFAULT``: redis cache address for the default cache (this **MUST** be set when using Docker). Defaults to: ``localhost:6379/0``.
-* ``CACHE_AXES``: redis cache address for the brute force login protection cache (this **MUST** be set when using Docker). Defaults to: ``localhost:6379/0``.
-* ``EMAIL_HOST``: hostname for the outgoing e-mail server (this **MUST** be set when using Docker). Defaults to: ``localhost``.
-
-
-Database
---------
-
-* ``DB_NAME``: name of the PostgreSQL database. Defaults to: ``openklant``.
-* ``DB_USER``: username of the database user. Defaults to: ``openklant``.
-* ``DB_PASSWORD``: password of the database user. Defaults to: ``openklant``.
-* ``DB_HOST``: hostname of the PostgreSQL database. Defaults to ``db`` for the docker environment, otherwise defaults to ``localhost``.
-* ``DB_PORT``: port number of the database. Defaults to: ``5432``.
-* ``DB_CONN_MAX_AGE``: The lifetime of a database connection, as an integer of seconds. Use 0 to close database connections at the end of each request — Django’s historical behavior. This setting is ignored if connection pooling is used. Defaults to: ``60``.
-* ``DB_POOL_ENABLED``: **Experimental:** Whether to use connection pooling. This feature is not yet recommended for production use. See the documentation for details: https://open-api-framework.readthedocs.io/en/latest/connection_pooling.html. Defaults to: ``False``.
-* ``DB_POOL_MIN_SIZE``: The minimum number of connection the pool will hold. The pool will actively try to create new connections if some are lost (closed, broken) and will try to never go below min_size. Defaults to: ``4``.
-* ``DB_POOL_MAX_SIZE``: The maximum number of connections the pool will hold. If None, or equal to min_size, the pool will not grow or shrink. If larger than min_size, the pool can grow if more than min_size connections are requested at the same time and will shrink back after the extra connections have been unused for more than max_idle seconds. Defaults to: ``None``.
-* ``DB_POOL_TIMEOUT``: The default maximum time in seconds that a client can wait to receive a connection from the pool (using connection() or getconn()). Note that these methods allow to override the timeout default. Defaults to: ``30``.
-* ``DB_POOL_MAX_WAITING``: Maximum number of requests that can be queued to the pool, after which new requests will fail, raising TooManyRequests. 0 means no queue limit. Defaults to: ``0``.
-* ``DB_POOL_MAX_LIFETIME``: The maximum lifetime of a connection in the pool, in seconds. Connections used for longer get closed and replaced by a new one. The amount is reduced by a random 10% to avoid mass eviction. Defaults to: ``3600``.
-* ``DB_POOL_MAX_IDLE``: Maximum time, in seconds, that a connection can stay unused in the pool before being closed, and the pool shrunk. This only happens to connections more than min_size, if max_size allowed the pool to grow. Defaults to: ``600``.
-* ``DB_POOL_RECONNECT_TIMEOUT``: Maximum time, in seconds, the pool will try to create a connection. If a connection attempt fails, the pool will try to reconnect a few times, using an exponential backoff and some random factor to avoid mass attempts. If repeated attempts fail, after reconnect_timeout second the connection attempt is aborted and the reconnect_failed() callback invoked. Defaults to: ``300``.
-* ``DB_POOL_NUM_WORKERS``: Number of background worker threads used to maintain the pool state. Background workers are used for example to create new connections and to clean up connections when they are returned to the pool. Defaults to: ``3``.
-
-
-Logging
--------
-
-* ``LOG_STDOUT``: whether to log to stdout or not. Defaults to: ``True``.
-* ``LOG_LEVEL``: control the verbosity of logging output. Available values are ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO`` and ``DEBUG``. Defaults to: ``INFO``.
-* ``LOG_QUERIES``: enable (query) logging at the database backend level. Note that you must also set ``DEBUG=1``, which should be done very sparingly!. Defaults to: ``False``.
-* ``LOG_REQUESTS``: enable logging of the outgoing requests. This must be enabled along with `LOG_OUTGOING_REQUESTS_DB_SAVE` to save outgoing request logs in the database. Defaults to: ``False``.
-* ``LOG_FORMAT_CONSOLE``: The format for the console logging handler, possible options: ``json``, ``plain_console``. Defaults to: ``json``.
-* ``ENABLE_STRUCTLOG_REQUESTS``: enable structured logging of requests. Defaults to: ``True``.
-* ``LOG_OUTGOING_REQUESTS_EMIT_BODY``: Whether or not outgoing request bodies should be logged. Defaults to: ``True``.
-* ``LOG_OUTGOING_REQUESTS_DB_SAVE``: Whether or not outgoing request logs should be saved to the database. Defaults to: ``False``.
-* ``LOG_OUTGOING_REQUESTS_DB_SAVE_BODY``: Whether or not outgoing request bodies should be saved to the database. Defaults to: ``True``.
-* ``LOG_OUTGOING_REQUESTS_MAX_AGE``: The amount of time after which request logs should be deleted from the database. Defaults to: ``7``.
-
-
-Cross-Origin-Resource-Sharing
------------------------------
-
-* ``CORS_ALLOW_ALL_ORIGINS``: allow cross-domain access from any client. Defaults to: ``False``.
-* ``CORS_ALLOWED_ORIGINS``: explicitly list the allowed origins for cross-domain requests. Example: http://localhost:3000,https://some-app.gemeente.nl. Defaults to: ``[]``.
-* ``CORS_ALLOWED_ORIGIN_REGEXES``: same as ``CORS_ALLOWED_ORIGINS``, but supports regular expressions. Defaults to: ``[]``.
-* ``CORS_EXTRA_ALLOW_HEADERS``: headers that are allowed to be sent as part of the cross-domain request. By default, Authorization, Accept-Crs and Content-Crs are already included. The value of this variable is added to these already included headers. Defaults to: ``[]``.
-
-
-Elastic APM
------------
-
-* ``ELASTIC_APM_SERVER_URL``: URL where Elastic APM is hosted. Defaults to: ``None``.
-* ``ELASTIC_APM_SERVICE_NAME``: Name of the service for this application in Elastic APM. Defaults to ``openklant - <environment>``.
-* ``ELASTIC_APM_SECRET_TOKEN``: Token used to communicate with Elastic APM. Defaults to: ``default``.
-* ``ELASTIC_APM_TRANSACTION_SAMPLE_RATE``: By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, set the sample rate to a value between 0.0 and 1.0. Defaults to: ``0.1``.
-
-
-Content Security Policy
------------------------
-
-* ``CSP_EXTRA_DEFAULT_SRC``: Extra default source URLs for CSP other than ``self``. Used for ``img-src``, ``style-src`` and ``script-src``. Defaults to: ``[]``.
-* ``CSP_EXTRA_FORM_ACTION``: Additional `form-action` sources. Defaults to: ``[]``.
-* ``CSP_FORM_ACTION``: Override the default `form-action` sources. Defaults to: ``['"\'self\'"']``.
-* ``CSP_EXTRA_IMG_SRC``: Extra `img-src` sources. Defaults to: ``[]``.
-* ``CSP_OBJECT_SRC``: `object-src` sources. Defaults to: ``['"\'none\'"']``.
-* ``CSP_REPORT_URI``: URI for CSP report-uri directive. Defaults to: ``None``.
-* ``CSP_REPORT_PERCENTAGE``: Fraction (between 0 and 1) of requests to include report-uri directive. Defaults to: ``0.0``.
-
-
-Optional
---------
-
-* ``SITE_ID``: The database ID of the site object. You usually won't have to touch this. Defaults to: ``1``.
-* ``DEBUG``: Only set this to ``True`` on a local development environment. Various other security settings are derived from this setting!. Defaults to: ``False``.
-* ``USE_X_FORWARDED_HOST``: whether to grab the domain/host from the X-Forwarded-Host header or not. This header is typically set by reverse proxies (such as nginx, traefik, Apache...). Note: this is a header that can be spoofed and you need to ensure you control it before enabling this. Defaults to: ``False``.
-* ``IS_HTTPS``: Used to construct absolute URLs and controls a variety of security settings. Defaults to the inverse of ``DEBUG``.
-* ``EMAIL_PORT``: port number of the outgoing e-mail server. Note that if you're on Google Cloud, sending e-mail via port 25 is completely blocked and you should use 487 for TLS. Defaults to: ``25``.
-* ``EMAIL_HOST_USER``: username to connect to the mail server. Defaults to: ``(empty string)``.
-* ``EMAIL_HOST_PASSWORD``: password to connect to the mail server. Defaults to: ``(empty string)``.
-* ``EMAIL_USE_TLS``: whether to use TLS or not to connect to the mail server. Should be True if you're changing the ``EMAIL_PORT`` to 487. Defaults to: ``False``.
-* ``DEFAULT_FROM_EMAIL``: The default email address from which emails are sent. Defaults to: ``openklant@example.com``.
-* ``SESSION_COOKIE_AGE``: For how long, in seconds, the session cookie will be valid. Defaults to: ``1209600``.
-* ``SESSION_COOKIE_SAMESITE``: The value of the SameSite flag on the session cookie. This flag prevents the cookie from being sent in cross-site requests thus preventing CSRF attacks and making some methods of stealing session cookie impossible.Currently interferes with OIDC. Keep the value set at Lax if used. Defaults to: ``Lax``.
-* ``CSRF_COOKIE_SAMESITE``: The value of the SameSite flag on the CSRF cookie. This flag prevents the cookie from being sent in cross-site requests. Defaults to: ``Strict``.
-* ``ENVIRONMENT``: An identifier for the environment, displayed in the admin depending on the settings module used and included in the error monitoring (see ``SENTRY_DSN``). The default is set according to ``DJANGO_SETTINGS_MODULE``.
-* ``SUBPATH``: If hosted on a subpath, provide the value here. If you provide ``/gateway``, the component assumes its running at the base URL: ``https://somedomain/gateway/``. Defaults to an empty string. Defaults to: ``None``.
-* ``RELEASE``: The version number or commit hash of the application (this is also sent to Sentry).
-* ``NUM_PROXIES``: the number of reverse proxies in front of the application, as an integer. This is used to determine the actual client IP adres. On Kubernetes with an ingress you typically want to set this to 2. Defaults to: ``1``.
-* ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``.
-* ``NOTIFICATIONS_DISABLED``: Indicates whether or not notifications should be sent to the Notificaties API for operations on the API endpoints. Defaults to: ``True``.
-* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``(empty string)``.
-* ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this.
-* ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``.
-* ``ENABLE_CLOUD_EVENTS``: **EXPERIMENTAL**: indicates whether or not cloud events should be sent to the configured endpoint for specific operations via the API (not ready for use in production). Defaults to: ``False``.
-* ``NOTIFICATIONS_SOURCE``: **EXPERIMENTAL**: the identifier of this application to use as the source in notifications and cloudevents. Defaults to: ``(empty string)``.
-
-
-
-
+.. config-all-params::
 
 Specifying the environment variables
 =====================================

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -141,7 +141,7 @@ django-jsonform==2.22.0
     #   open-api-framework
 django-localflavor==4.0
     # via -r requirements/base.in
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.9.1
     # via open-api-framework
 django-markup==1.8.1
     # via open-api-framework
@@ -152,7 +152,9 @@ django-otp==1.5.1
 django-phonenumber-field==7.3.0
     # via django-two-factor-auth
 django-privates==3.1.1
-    # via django-simple-certmanager
+    # via
+    #   django-simple-certmanager
+    #   open-api-framework
 django-redis==5.4.0
     # via open-api-framework
 django-relativedelta==2.0.0
@@ -169,7 +171,9 @@ django-setup-configuration==0.11.0
     #   mozilla-django-oidc-db
     #   open-api-framework
 django-simple-certmanager==2.3.0
-    # via zgw-consumers
+    # via
+    #   open-api-framework
+    #   zgw-consumers
 django-solo==2.3.0
     # via
     #   commonground-api-common
@@ -252,7 +256,9 @@ maykin-2fa==1.0.1
     #   maykin-common
     #   open-api-framework
 maykin-common==0.19.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   open-api-framework
 mdurl==0.1.2
     # via markdown-it-py
 mozilla-django-oidc==5.0.2
@@ -263,7 +269,7 @@ mozilla-django-oidc-db==2.0.1
     #   open-api-framework
 notifications-api-common==0.10.1
     # via commonground-api-common
-open-api-framework==0.13.4
+open-api-framework==0.14.0
     # via -r requirements/base.in
 opentelemetry-api==1.36.0
     # via
@@ -378,7 +384,9 @@ pydantic-core==2.27.1
 pydantic-settings==2.6.1
     # via django-setup-configuration
 pygments==2.20.0
-    # via rich
+    # via
+    #   django-log-outgoing-requests
+    #   rich
 pyjwt==2.12.1
     # via
     #   commonground-api-common
@@ -393,9 +401,7 @@ python-dateutil==2.9.0.post0
     #   celery
     #   django-relativedelta
 python-decouple==3.8
-    # via
-    #   maykin-common
-    #   open-api-framework
+    # via maykin-common
 python-dotenv==1.0.1
     # via
     #   open-api-framework
@@ -465,6 +471,7 @@ typer==0.21.1
     # via maykin-common
 typing-extensions==4.12.2
     # via
+    #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -251,7 +251,7 @@ maykin-2fa==1.0.1
     # via
     #   maykin-common
     #   open-api-framework
-maykin-common==0.18.0
+maykin-common==0.19.0
     # via -r requirements/base.in
 mdurl==0.1.2
     # via markdown-it-py

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -486,7 +486,7 @@ maykin-2fa==1.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
-maykin-common==0.18.0
+maykin-common==0.19.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -237,7 +237,7 @@ django-localflavor==4.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.9.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -266,6 +266,7 @@ django-privates==3.1.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-simple-certmanager
+    #   open-api-framework
 django-redis==5.4.0
     # via
     #   -c requirements/base.txt
@@ -299,6 +300,7 @@ django-simple-certmanager==2.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   open-api-framework
     #   zgw-consumers
 django-solo==2.3.0
     # via
@@ -490,6 +492,7 @@ maykin-common==0.19.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   open-api-framework
 mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
@@ -514,7 +517,7 @@ notifications-api-common==0.10.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.13.4
+open-api-framework==0.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -713,6 +716,7 @@ pygments==2.20.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-log-outgoing-requests
     #   rich
     #   sphinx
     #   sphinx-tabs
@@ -749,7 +753,6 @@ python-decouple==3.8
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-common
-    #   open-api-framework
 python-dotenv==1.0.1
     # via
     #   -c requirements/base.txt
@@ -918,6 +921,7 @@ typing-extensions==4.12.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -291,7 +291,7 @@ django-localflavor==4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.9.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -320,6 +320,7 @@ django-privates==3.1.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-simple-certmanager
+    #   open-api-framework
 django-redis==5.4.0
     # via
     #   -c requirements/ci.txt
@@ -355,6 +356,7 @@ django-simple-certmanager==2.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   open-api-framework
     #   zgw-consumers
 django-solo==2.3.0
     # via
@@ -588,6 +590,7 @@ maykin-common==0.19.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   open-api-framework
 mccabe==0.7.0
     # via
     #   -c requirements/ci.txt
@@ -620,7 +623,7 @@ notifications-api-common==0.10.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.13.4
+open-api-framework==0.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -838,6 +841,7 @@ pygments==2.20.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-log-outgoing-requests
     #   rich
     #   sphinx
     #   sphinx-tabs
@@ -884,7 +888,6 @@ python-decouple==3.8
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-common
-    #   open-api-framework
 python-dotenv==1.0.1
     # via
     #   -c requirements/ci.txt
@@ -1116,6 +1119,7 @@ typing-extensions==4.12.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   anyio
+    #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -584,7 +584,7 @@ maykin-2fa==1.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
-maykin-common==0.18.0
+maykin-common==0.19.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openklant/conf/base.py
+++ b/src/openklant/conf/base.py
@@ -1,14 +1,15 @@
 import os
 
+from maykin_common.config import config  # noqa
 from notifications_api_common.settings import *  # noqa
 
 os.environ["_USE_STRUCTLOG"] = "True"
 
 from open_api_framework.conf.base import *  # noqa
-from open_api_framework.conf.utils import config  # noqa
 from upgrade_check import UpgradeCheck, VersionRange
 from upgrade_check.constraints import UpgradePaths
 from maykin_common.health_checks import default_health_check_apps
+from maykin_common.config import DocumentationParams
 from .api import *  # noqa
 
 #
@@ -37,15 +38,19 @@ MIDDLEWARE += ["openklant.utils.middleware.APIVersionHeaderMiddleware"]
 
 ENABLE_CLOUD_EVENTS = config(
     "ENABLE_CLOUD_EVENTS",
-    default=False,
+    default="False",
     cast=bool,
-    help_text="**EXPERIMENTAL**: indicates whether or not cloud events should be sent to the configured endpoint for specific operations via the API (not ready for use in production)",
+    documentation=DocumentationParams(
+        help_text="**EXPERIMENTAL**: indicates whether or not cloud events should be sent to the configured endpoint for specific operations via the API (not ready for use in production)",
+    ),
 )
 
 NOTIFICATIONS_SOURCE = config(
     "NOTIFICATIONS_SOURCE",
     default="",
-    help_text="**EXPERIMENTAL**: the identifier of this application to use as the source in notifications and cloudevents",
+    documentation=DocumentationParams(
+        help_text="**EXPERIMENTAL**: the identifier of this application to use as the source in notifications and cloudevents",
+    ),
 )
 
 #
@@ -100,21 +105,23 @@ SETUP_CONFIGURATION_STEPS = (
 CELERY_TASK_TIME_LIMIT = config(
     "CELERY_TASK_HARD_TIME_LIMIT",
     default=15 * 60,
-    help_text=(
-        "Defaults to: ``900`` seconds. "
-        "If a celery task exceeds this time limit, the worker processing the task will "
-        "be killed and replaced with a new one."
+    documentation=DocumentationParams(
+        help_text=(
+            "If a celery task exceeds this time limit (in seconds), the worker "
+            "processing the task will be killed and replaced with a new one."
+        ),
+        group="Celery",
     ),
-    group="Celery",
 )  # hard
 CELERY_TASK_SOFT_TIME_LIMIT = config(
     "CELERY_TASK_SOFT_TIME_LIMIT",
     default=5 * 60,
-    help_text=(
-        "Defaults to: ``300`` seconds. "
-        "If a celery task exceeds this time limit, the ``SoftTimeLimitExceeded`` exception will be raised."
+    documentation=DocumentationParams(
+        help_text=(
+            "If a celery task exceeds this time limit (in seconds), the ``SoftTimeLimitExceeded`` exception will be raised."
+        ),
+        group="Celery",
     ),
-    group="Celery",
 )  # soft
 
 #
@@ -123,7 +130,7 @@ CELERY_TASK_SOFT_TIME_LIMIT = config(
 CELERY_ONCE_REDIS_URL = config(
     "CELERY_ONCE_REDIS_URL",
     default=CELERY_BROKER_URL,
-    group="Celery",
+    documentation=no_doc,
 )
 CELERY_ONCE = {
     "backend": "celery_once.backends.Redis",
@@ -140,9 +147,11 @@ CELERY_ONCE = {
 NOTIFICATIONS_DISABLED = config(
     "NOTIFICATIONS_DISABLED",
     default=True,
-    help_text=(
-        "Indicates whether or not notifications should be sent to the Notificaties API "
-        "for operations on the API endpoints."
+    documentation=DocumentationParams(
+        help_text=(
+            "Indicates whether or not notifications should be sent to the Notificaties API "
+            "for operations on the API endpoints."
+        ),
     ),
 )
 

--- a/src/openklant/conf/dev.py
+++ b/src/openklant/conf/dev.py
@@ -24,6 +24,7 @@ os.environ.setdefault("OTEL_SDK_DISABLED", "true")
 os.environ.setdefault("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "true")
 
 from .base import *  # noqa isort:skip
+from maykin_common.config import no_doc
 
 # Feel free to switch dev to sqlite3 for simple projects,
 # os.environ.setdefault("DB_ENGINE", "django.db.backends.sqlite3")
@@ -110,7 +111,7 @@ DEBUG_TOOLBAR_PANELS = [
 #
 # DJANGO-SILK
 #
-if config("PROFILE", default=False, add_to_docs=False):
+if config("PROFILE", default=False, documentation=no_doc):
     INSTALLED_APPS += ["silk"]
     MIDDLEWARE = ["silk.middleware.SilkyMiddleware"] + MIDDLEWARE
     security_index = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")

--- a/src/openklant/conf/docker.py
+++ b/src/openklant/conf/docker.py
@@ -1,11 +1,11 @@
 import os
 
-from open_api_framework.conf.utils import config
+from maykin_common.config import config
 
-os.environ.setdefault("DB_USER", config("DATABASE_USER", "openklant"))
-os.environ.setdefault("DB_NAME", config("DATABASE_NAME", "openklant"))
-os.environ.setdefault("DB_PASSWORD", config("DATABASE_PASSWORD", ""))
-os.environ.setdefault("DB_HOST", config("DATABASE_HOST", "db"))
+os.environ.setdefault("DB_USER", config("DATABASE_USER", default="openklant"))
+os.environ.setdefault("DB_NAME", config("DATABASE_NAME", default="openklant"))
+os.environ.setdefault("DB_PASSWORD", config("DATABASE_PASSWORD", default=""))
+os.environ.setdefault("DB_HOST", config("DATABASE_HOST", default="db"))
 os.environ.setdefault("DB_CONN_MAX_AGE", "60")
 
 os.environ.setdefault("ENVIRONMENT", "docker")

--- a/src/openklant/templates/open_api_framework/env_config.rst
+++ b/src/openklant/templates/open_api_framework/env_config.rst
@@ -1,7 +1,0 @@
-{% extends "open_api_framework/env_config.rst" %}
-
-{% block intro %}
-Open Klant can be ran both as a Docker container or directly on a VPS or
-dedicated server. It relies on other services, such as database and cache
-backends, which can be configured through environment variables.
-{% endblock %}


### PR DESCRIPTION
Fixes maykinmedia/open-api-framework#83 partially

Related PRs:
- https://github.com/maykinmedia/django-common/pull/34
- https://github.com/maykinmedia/open-api-framework/pull/183 (needs release)

**Changes**

* Use sphinx directive to generate envvar documentation
* Remove old management command generated docs
* Upgrade maykin-common to 0.19.0
* Upgrade OAF to 0.14.0 -> which also changes django-log-outgoing-requests config defaults to be in line with Open Forms

