### PR TITLE
:bug: [#510] Add missing raw_id_fields for PartijAdmin

### DIFF
--- a/src/openklant/components/klantinteracties/admin/actoren.py
+++ b/src/openklant/components/klantinteracties/admin/actoren.py
@@ -31,6 +31,7 @@ class OrganisatorischeEenheidInlineAdmin(admin.StackedInline):
 class ActorKlantcontactInlineAdmin(admin.StackedInline):
     readonly_fields = ("uuid",)
     model = ActorKlantcontact
+    raw_id_fields = ("klantcontact",)
     extra = 0
 
 

--- a/src/openklant/components/klantinteracties/admin/internetaken.py
+++ b/src/openklant/components/klantinteracties/admin/internetaken.py
@@ -40,4 +40,5 @@ class InterneTaakAdmin(admin.ModelAdmin):
         "uuid",
         "toegewezen_op",
     )
+    raw_id_fields = ("klantcontact",)
     inlines = (ActorInlineAdmin,)

--- a/src/openklant/components/klantinteracties/admin/klantcontacten.py
+++ b/src/openklant/components/klantinteracties/admin/klantcontacten.py
@@ -154,7 +154,7 @@ class BetrokkeneAdmin(admin.ModelAdmin):
 class OnderwerpobjectInlineAdmin(admin.StackedInline):
     model = Onderwerpobject
     fk_name = "klantcontact"
-    raw_id_field = ["klantcontact"]
+    raw_id_fields = ("was_klantcontact",)
     readonly_fields = ("uuid",)
     extra = 0
 
@@ -169,6 +169,7 @@ class ActorKlantcontactInlineAdmin(admin.StackedInline):
     model = ActorKlantcontact
     extra = 0
     readonly_fields = ("uuid",)
+    raw_id_fields = ("actor",)
 
 
 @admin.register(Klantcontact)

--- a/src/openklant/components/klantinteracties/admin/partijen.py
+++ b/src/openklant/components/klantinteracties/admin/partijen.py
@@ -126,18 +126,21 @@ class PartijIdentificatorInlineAdmin(admin.StackedInline):
     readonly_fields = ("uuid",)
     model = PartijIdentificator
     form = PartijIdentificatorAdminForm
+    raw_id_fields = ("sub_identificator_van",)
     extra = 0
 
 
 class BetrokkeneInlineAdmin(admin.StackedInline):
     readonly_fields = ("uuid",)
     model = Betrokkene
+    raw_id_fields = ("klantcontact",)
     extra = 0
 
 
 class DigitaalAdresInlineAdmin(admin.StackedInline):
     readonly_fields = ("uuid",)
     model = DigitaalAdres
+    raw_id_fields = ("betrokkene",)
     extra = 0
 
 
@@ -157,13 +160,14 @@ class VertegenwoordigdenInlineAdmin(admin.StackedInline):
     model = Vertegenwoordigden
     fk_name = "vertegenwoordigende_partij"
     extra = 0
+    raw_id_fields = ("vertegenwoordigde_partij",)
 
 
 class ContactpersoonInlineAdmin(admin.StackedInline):
     readonly_fields = ("uuid",)
     model = Contactpersoon
     fk_name = "partij"
-    raw_id_field = ["partij"]
+    raw_id_fields = ("werkte_voor_partij",)
     extra = 0
 
 
@@ -299,3 +303,31 @@ class CategorieAdmin(admin.ModelAdmin):
         "uuid",
         "naam",
     )
+
+
+@admin.register(PartijIdentificator)
+class PartijIdentificatorAdmin(admin.ModelAdmin):
+    readonly_fields = ("uuid",)
+    search_fields = (
+        "uuid",
+        "partij__uuid",
+        "partij_identificator_object_id",
+        "sub_identificator_van__uuid",
+        "sub_identificator_van__partij_identificator_object_id",
+    )
+    list_filter = (
+        "partij_identificator_code_objecttype",
+        "partij_identificator_code_soort_object_id",
+        "partij_identificator_code_register",
+    )
+    fields = (
+        "uuid",
+        "partij",
+        "sub_identificator_van",
+        "andere_partij_identificator",
+        "partij_identificator_code_objecttype",
+        "partij_identificator_code_soort_object_id",
+        "partij_identificator_object_id",
+        "partij_identificator_code_register",
+    )
+    raw_id_fields = ("partij",)

--- a/src/openklant/components/klantinteracties/tests/test_admin.py
+++ b/src/openklant/components/klantinteracties/tests/test_admin.py
@@ -629,7 +629,7 @@ class IntereTaakAdminTests(WebTest):
         form = response.forms["internetaak_form"]
         form["internetakenactorenthoughmodel_set-TOTAL_FORMS"] = 1
 
-        form["klantcontact"].select(text=str(klantcontact))
+        form["klantcontact"] = str(klantcontact.pk)
         form["nummer"] = "0000000001"
         form["gevraagde_handeling"] = "Terugbellen"
         form["toelichting"] = "bla bla bla"
@@ -675,7 +675,7 @@ class IntereTaakAdminTests(WebTest):
         response: TestResponse = self.app.get(admin_url)
 
         form = response.forms["internetaak_form"]
-        form["klantcontact"].select(text=str(klantcontact))
+        form["klantcontact"] = str(klantcontact.pk)
         form["gevraagde_handeling"] = "Terugbellen"
         form["status"].select(text=_(Taakstatus.verwerkt.label))
 
@@ -714,7 +714,7 @@ class IntereTaakAdminTests(WebTest):
         response: TestResponse = self.app.get(admin_url)
 
         form = response.forms["internetaak_form"]
-        form["klantcontact"].select(text=str(klantcontact2))
+        form["klantcontact"] = str(klantcontact2.pk)
         form["nummer"] = "0000000009"
         form["gevraagde_handeling"] = "Terugbellen"
         form["toelichting"] = "bla bla bla"

--- a/src/openklant/fixtures/default_admin_index.json
+++ b/src/openklant/fixtures/default_admin_index.json
@@ -29,6 +29,14 @@
             [
                 "klantinteracties",
                 "partijidentificator"
+            ],
+            [
+                "klantinteracties",
+                "digitaaladres"
+            ],
+            [
+                "klantinteracties",
+                "betrokkene"
             ]
         ]
     }

--- a/src/openklant/fixtures/default_admin_index.json
+++ b/src/openklant/fixtures/default_admin_index.json
@@ -25,6 +25,10 @@
             [
                 "klantinteracties",
                 "partij"
+            ],
+            [
+                "klantinteracties",
+                "partijidentificator"
             ]
         ]
     }


### PR DESCRIPTION
and other admin pages that were missing this as well, to make sure the admin still loads fast if there are a lot of possible options for related objects

Fixes #510 

**Changes**

* Add missing raw_id_fields for PartijAdmin and other admin pages

