### PR TITLE
Avoid using `event` key in uwsgi logs

### DIFF
--- a/bin/uwsgi.ini
+++ b/bin/uwsgi.ini
@@ -16,8 +16,9 @@ log-route = uwsgilogger ^((?!\{).)*$
 
 ; leave already JSON formatted django logs as is
 log-encoder = format:djangologger ${msg}
-; Encode uWSGI server logs as JSON
-log-encoder = json:uwsgilogger {"source": "uwsgi", "type": "server", "timestamp": "${strftime:%%Y-%%m-%%dT%%H:%%M:%%S%%z}", "event": "${msg}", "level": "info"}
+; Encode uWSGI server logs as JSON - deliberately using msg instead of event due to
+; high cardinality of this key/label.
+log-encoder = json:uwsgilogger {"source": "uwsgi", "type": "server", "timestamp": "${strftime:%%Y-%%m-%%dT%%H:%%M:%%S%%z}", "msg": "${msg}", "level": "info"}
 
 ; these are uwsgi's own request logs (not to be confused with the request logs emitted
 ; by the application!)


### PR DESCRIPTION
Updated from `event` to `msg` for high-cardinality log messages, so that we can enable indexing on the `event` key.

