### PR TITLE
:construction_worker: Fix uwsgi strict-mode crash by renaming UWSGI_PORT to OPENKLANT_PORT

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -9,7 +9,7 @@ export PGPORT=${DB_PORT:-5432}
 
 fixtures_dir=${FIXTURES_DIR:-/app/fixtures}
 
-uwsgi_port=${UWSGI_PORT:-8000}
+uwsgi_port=${OPENKLANT_PORT:-8000}
 uwsgi_processes=${UWSGI_PROCESSES:-4}
 uwsgi_threads=${UWSGI_THREADS:-4}
 


### PR DESCRIPTION
Fixes #

**Changes**

[Describe the changes here]

**Checklist**

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/maykinmedia/open-klant/wiki/Architectural-Decision-Records-(ADR))
