### PR TITLE
:construction_worker: [maykinmedia/open-api-workflows#60] Reenable OAS lint job with vacuum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: image-name
 
   open-api-ci:
-    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
     permissions:
@@ -125,7 +125,7 @@ jobs:
       django-settings-module: openklant.conf.ci
 
   open-api-publish:
-    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
       - open-api-ci

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   open-api-workflow-code-analysis:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   open-api-workflow-code-quality:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       python-version: "3.12"
       node-version: "24"

--- a/.github/workflows/oaf-check.yml
+++ b/.github/workflows/oaf-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   open-api-workflow-check-oas:
-    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
 
     with:
       python-version: '3.12'

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,41 +1,41 @@
-# name: OAS
+name: OAS
 
-# on:
-#   push:
-#     branches:
-#       - master
-#       - stable/*
-#     tags:
-#       - '*'
-#   pull_request:
-#   workflow_dispatch:
+on:
+  push:
+    branches:
+      - master
+      - stable/*
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
 
-# # least privilege as default, should be overridden per job if necessary
-# permissions:
-#   contents: read
+# least privilege as default, should be overridden per job if necessary
+permissions:
+  contents: read
 
-# jobs:
-#   oas:
-#     name: Checks
+jobs:
+  oas:
+    name: Checks
 
-#     strategy:
-#       matrix:
-#         component:
-#           - contactgegevens
-#           - klantinteracties
+    strategy:
+      matrix:
+        component:
+          - contactgegevens
+          - klantinteracties
 
-#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-#     with:
-#       python-version: '3.12'
-#       django-settings-module: openklant.conf.ci
-#       oas-generate-command: >2
-#         bin/generate_schema_for_component.sh ${{ matrix.component }}
-#         src/openklant/components/${{ matrix.component }}/openapi.yaml
-#       schema-path: src/openklant/components/${{ matrix.component }}/openapi.yaml
-#       oas-artifact-name: ${{ matrix.component }}-api-oas
-#       node-version-file: '.nvmrc'
-#       spectral-version: '^6.15.0'
-#       openapi-to-postman-version: '^5.0.0'
-#       postman-artifact-name: ${{ matrix.component }}-api-postman-collection
-#       openapi-generator-version: '^2.20.0'
-#       spectral-ruleset: ruleset.yaml
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
+    with:
+      python-version: '3.12'
+      django-settings-module: openklant.conf.ci
+      oas-generate-command: >2
+        bin/generate_schema_for_component.sh ${{ matrix.component }}
+        src/openklant/components/${{ matrix.component }}/openapi.yaml
+      schema-path: src/openklant/components/${{ matrix.component }}/openapi.yaml
+      oas-artifact-name: ${{ matrix.component }}-api-oas
+      node-version-file: '.nvmrc'
+      openapi-to-postman-version: '^5.0.0'
+      postman-artifact-name: ${{ matrix.component }}-api-postman-collection
+      openapi-generator-version: '^2.20.0'
+      spectral-ruleset: ruleset.yaml
+      vacuum-custom-functions: vacuum_functions

--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   open-api-workflow-quick-start:
-    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       fixtures: 'klantinteracties contactgegevens'
 

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,4 +1,7 @@
 # 2.1 ruleset got changed without a version increase
-extends: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml
+# vacuum supports the extends syntax and can fetch external rulesets, but the original
+# URL (https://static.developer.overheid.nl/adr/2.1/ruleset.yaml) returns the linter as
+# a file download, which vacuum doesn't support currently
+extends: https://raw.githubusercontent.com/Logius-standaarden/API-Design-Rules/refs/tags/v2.1.0/linter/spectral.yml
 rules:
   paths-open-api-json-resource-exists: warn

--- a/vacuum_functions/or.js
+++ b/vacuum_functions/or.js
@@ -1,0 +1,24 @@
+// The Logius API design rules make use of the function `or`, which vacuum does not
+// support
+function getSchema() {
+  return {
+    name: "or",
+    description: "Passes if any configured property exists."
+  };
+}
+
+function runRule(input) {
+  const properties = context.rule.then.functionOptions.properties || [];
+
+  for (const property of properties) {
+    if (Object.prototype.hasOwnProperty.call(input, property)) {
+      return [];
+    }
+  }
+
+  return [
+    {
+      message: "None of the required properties were found."
+    }
+  ];
+}


### PR DESCRIPTION
Fixes maykinmedia/open-api-workflows#60 partially

Summary of vacuum can be seen here: https://github.com/maykinmedia/open-klant/actions/runs/31161214409

**Changes**

* upgrade open-api-workflows to v7.0.0 and re-enable OAS lint job

**Checklist**

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/maykinmedia/open-klant/wiki/Architectural-Decision-Records-(ADR))
