### PR TITLE
:construction_worker: Group dependabot updates for actions into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7


### PR DESCRIPTION
instead of one per action

Fixes #

**Changes**

[Describe the changes here]

**Checklist**

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/maykinmedia/open-klant/wiki/Architectural-Decision-Records-(ADR))
