### PR TITLE
:fire: Remove unused celery-once setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,6 @@ jobs:
         env:
           SECRET_KEY: dummy
           CELERY_BROKER_URL: 'redis://bad-host:6379/0'
-          # specified explicitly, since the broker URL is broken, but the once backend
-          # needs to be available even with CELERY_TASK_ALWAYS_EAGER
-          CELERY_ONCE_REDIS_URL: 'redis://localhost:6379/0'
 
       - name: Publish coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/src/openklant/conf/base.py
+++ b/src/openklant/conf/base.py
@@ -126,22 +126,6 @@ CELERY_TASK_SOFT_TIME_LIMIT = config(
 )  # soft
 
 #
-# CELERY-ONCE
-#
-CELERY_ONCE_REDIS_URL = config(
-    "CELERY_ONCE_REDIS_URL",
-    default=CELERY_BROKER_URL,
-    documentation=no_doc,
-)
-CELERY_ONCE = {
-    "backend": "celery_once.backends.Redis",
-    "settings": {
-        "url": CELERY_ONCE_REDIS_URL,
-        "default_timeout": 60 * 60,  # one hour
-    },
-}
-
-#
 # Notifications
 #
 # Override the default to be `True`, to make notifications opt-in


### PR DESCRIPTION
Discovered from https://github.com/open-zaak/open-zaak/pull/2468#discussion_r3621346070 
`celery-once` setting was added but never actually set up (no task uses the QueueOnce base or `once` config)

